### PR TITLE
Simulation: Use parameters method to pass and set parameters

### DIFF
--- a/src/rtctools/simulation/csv_mixin.py
+++ b/src/rtctools/simulation/csv_mixin.py
@@ -129,16 +129,6 @@ class CSVMixin(SimulationProblem):
         # Set up experiment
         self.setup_experiment(0, self.__timeseries_times_sec[-1], self.__dt)
 
-        # Load parameters from parameter config
-        self.__parameter_variables = set(self.get_parameter_variables())
-
-        logger.debug("Model parameters are {}".format(self.__parameter_variables))
-
-        for parameter, value in self.__parameters.items():
-            if parameter in self.__parameter_variables:
-                logger.debug("CSVMixin: Setting parameter {} = {}".format(parameter, value))
-                self.set_var(parameter, value)
-
         # Load input variable names
         self.__input_variables = set(self.get_input_variables().keys())
 
@@ -233,8 +223,8 @@ class CSVMixin(SimulationProblem):
         parameters.update(self.__parameters)
 
         if logger.getEffectiveLevel() == logging.DEBUG:
-            for parameter in self.__parameters:
-                logger.debug("CSVMixin: Read parameter {} ".format(parameter))
+            for parameter, value in self.__parameters.items():
+                logger.debug("CSVMixin: Setting parameter {} = {}".format(parameter, value))
 
         return parameters
 

--- a/src/rtctools/simulation/pi_mixin.py
+++ b/src/rtctools/simulation/pi_mixin.py
@@ -135,16 +135,6 @@ class PIMixin(SimulationProblem):
         # Set up experiment
         self.setup_experiment(0, self.__timeseries_import_times[-1], self.__dt)
 
-        # Load parameters from parameter config
-        self.__parameter_variables = set(self.get_parameter_variables())
-
-        logger.debug("Model parameters are {}".format(self.__parameter_variables))
-
-        for parameter, value in self.__parameters.items():
-            if parameter in self.__parameter_variables:
-                logger.debug("PIMixin: Setting parameter {} = {}".format(parameter, value))
-                self.set_var(parameter, value)
-
         # Load input variable names
         self.__input_variables = set(self.get_input_variables().keys())
 
@@ -263,8 +253,8 @@ class PIMixin(SimulationProblem):
         parameters.update(self.__parameters)
 
         if logger.getEffectiveLevel() == logging.DEBUG:
-            for parameter in self.__parameters:
-                logger.debug("CSVMixin: Read parameter {} ".format(parameter))
+            for parameter, value in self.__parameters.items():
+                logger.debug("PIMixin: Setting parameter {} = {}".format(parameter, value))
 
         return parameters
 


### PR DESCRIPTION
In GitLab by @jvande42b on Jun 27, 2018, 05:53

Before this commit, the parameters method was implemented by all the
simulation mixins, but went unused. This resulted in confusing behaviour.
Furthermore, the various mixins would set parameters in their own
overwritten implementations of initialize().

With this commit, simulation child classes and mixins can override the
parameters() method to set parameters instead of needing to implement
and maintian their own set_var() logic. This also makes it much more
transparent to the user what the values of the parameters are and which
class takes precedence when setting parameters.