### PR TITLE
solver_utils: add custom solver library preloading support

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -1,0 +1,9 @@
+Advanced Topics
+===============
+
+This section covers advanced RTC-Tools features and configurations.
+
+.. toctree::
+   :maxdepth: 2
+
+   advanced/custom_solver_versions

--- a/doc/advanced/custom_solver_versions.rst
+++ b/doc/advanced/custom_solver_versions.rst
@@ -1,0 +1,219 @@
+Using Custom Solver Versions
+=============================
+
+By default, RTC-Tools uses the solver libraries bundled with CasADi. However, you may need to use different versions of solvers like HiGHS, IPOPT, or others for various reasons:
+
+* **Performance improvements** in newer solver releases
+* **Bug fixes** available in specific versions
+* **New features** not yet in CasADi's bundled version
+* **Custom builds** optimized for your hardware or compiled with specific options
+* **Version consistency** across development and production environments
+
+This guide explains how to use custom solver library versions with RTC-Tools.
+
+.. warning::
+   Custom solver libraries must be ABI-compatible with CasADi's expectations. Using incompatible builds may cause crashes or unexpected behavior.
+
+How It Works
+------------
+
+RTC-Tools uses Python's ``ctypes`` module to **preload** custom solver libraries **before** CasADi loads its bundled versions. The preloading happens automatically at package initialization when the ``RTCTOOLS_PRELOAD_SOLVER_LIBS`` environment variable is set, or explicitly via function call.
+
+Method 1: Environment Variable (Recommended for Deployment)
+------------------------------------------------------------
+
+The simplest approach is to set the ``RTCTOOLS_PRELOAD_SOLVER_LIBS`` environment variable before running your application.
+
+**Linux/macOS:**
+
+.. code-block:: bash
+
+   export RTCTOOLS_PRELOAD_SOLVER_LIBS="highs:/opt/highs-1.12/lib/libhighs.so"
+   python my_optimization_script.py
+
+**Windows:**
+
+.. code-block:: batch
+
+   set RTCTOOLS_PRELOAD_SOLVER_LIBS=highs:C:\highs-1.12\bin\libhighs.dll
+   python my_optimization_script.py
+
+To make MinGW-built solvers work, ensure the required runtime DLLs
+(``libgcc_s_seh-1.dll``, ``libstdc++-6.dll``, ``libwinpthread-1.dll``, etc.) are
+available when the library loads. You can either add the directory containing
+those DLLs to your ``PATH`` environment variable, or copy the DLLs into the same
+directory as ``libhighs.dll`` so they are discovered alongside the solver.
+
+**Multiple Solvers:**
+
+.. code-block:: bash
+
+   export RTCTOOLS_PRELOAD_SOLVER_LIBS="highs:/path/libhighs.so,ipopt:/path/libipopt.so"
+
+**Docker/Container Environments:**
+
+.. code-block:: dockerfile
+
+   FROM python:3.11
+
+   # Install custom HiGHS solver
+   COPY libhighs.so /opt/highs/lib/
+
+   # Set environment variable for RTC-Tools
+   ENV RTCTOOLS_PRELOAD_SOLVER_LIBS="highs:/opt/highs/lib/libhighs.so"
+
+   # Install RTC-Tools
+   RUN pip install rtc-tools
+
+   # Your application code
+   COPY . /app
+   WORKDIR /app
+   CMD ["python", "run_optimization.py"]
+
+Method 2: Explicit Function Call (Recommended for Development)
+---------------------------------------------------------------
+
+For more control, explicitly preload in your Python code before importing optimization modules:
+
+.. code-block:: python
+
+   from rtctools.solver_utils import preload_custom_solver_library
+
+   # Preload BEFORE importing any optimization modules
+   preload_custom_solver_library('/opt/highs-1.12/lib/libhighs.so', 'HiGHS')
+
+   # Now import and use optimization modules
+   from rtctools.optimization.collocated_integrated_optimization_problem import (
+       CollocatedIntegratedOptimizationProblem
+   )
+
+   class MyProblem(CollocatedIntegratedOptimizationProblem):
+       def solver_options(self):
+           options = super().solver_options()
+           options['solver'] = 'highs'
+           return options
+       # ... rest of implementation
+
+   problem = MyProblem()
+   problem.optimize()
+
+Verifying Custom Solver is Used
+--------------------------------
+
+Use ``get_solver_library_info()`` to confirm preloading succeeded:
+
+.. code-block:: python
+
+   from rtctools.solver_utils import get_solver_library_info
+
+   info = get_solver_library_info('highs')
+
+   if info['preloaded']:
+       print(f"✓ Using custom HiGHS from: {info['preloaded_path']}")
+   else:
+       print("✗ Using CasADi bundled HiGHS")
+       if 'casadi_bundled_library_path' in info:
+           print(f"  Bundled library: {info['casadi_bundled_library_path']}")
+
+Troubleshooting
+---------------
+
+**FileNotFoundError: Solver library not found**
+
+The path is wrong or the file is unreadable. Verify the path, make sure the file exists, and confirm it has read permissions.
+
+**RuntimeError: Failed to preload**
+
+Usually indicates missing dependencies or an ABI mismatch. Check for missing libraries with ``ldd`` (Linux) or ``otool -L`` (macOS), use the `Dependencies <https://github.com/lucasg/Dependencies>`_ tool on Windows, and confirm the build matches CasADi's compiler, bitness, and C++ runtime.
+
+**"CasADi already imported" warning**
+
+CasADi loads before preloading runs (for example, after importing ``rtctools.optimization`` directly). Import ``rtctools`` or call ``preload_custom_solver_library()`` before any CasADi-dependent modules. Use ``check_preload_import_order()`` if you want the process to fail fast when the order is wrong.
+
+**Solver still reports bundled version**
+
+Check logs for preload errors, confirm the import order, and inspect ``get_solver_library_info()`` for the active paths.
+
+Compatibility Notes
+-------------------
+
+* **HiGHS**: Only solver validated with this guide; its C API has been stable since v1.7.0.
+* **IPOPT on Windows**: Preloading does not work with precompiled binaries - publicly available IPOPT binaries are compiled with Intel compilers while CasADi's Windows wheels use GCC/MinGW, causing ABI incompatibility. Julia's GCC-compiled IPOPT binaries also fail due to missing dependencies. Workaround: use preloading in a Linux environment (e.g., Docker, WSL2, native Linux) with conda-forge GCC-compiled IPOPT binaries.
+* Other CasADi solvers may work with the same approach, but they have not been officially tested. Validate thoroughly before relying on them in production.
+* Requires Python 3.7+ (``ctypes`` standard library) and CasADi 3.6.0 or newer for the preload hooks used here.
+
+Solver Coverage
+^^^^^^^^^^^^^^^
+
+We have confirmed this workflow with HiGHS. If you preload other solvers (IPOPT, BONMIN, CBC, etc.), treat them as experimental and perform end-to-end validation. Commercial solvers typically ship their own integration tooling and may not benefit from this preload pathway.
+
+Testing Your Setup
+------------------
+
+RTC-Tools includes a standalone integration test script:
+
+.. code-block:: bash
+
+   python tests/optimization/test_solver_preload_integration.py
+
+Run it in a fresh Python process since CasADi cannot be reloaded once imported.
+
+Best Practices
+--------------
+
+1. **Test thoroughly** - Verify your custom solver produces correct results with your models
+2. **Verify preloading** - Use ``get_solver_library_info()`` to confirm custom library loaded
+3. **Document versions** - Keep records of which solver versions work with your application
+4. **Use environment variables in production** - Easier to manage in deployment pipelines
+5. **Version pin** - Specify exact solver versions in your documentation
+6. **Container builds** - Include custom solvers in Docker images for reproducibility
+7. **CI/CD integration** - Test with custom solvers in continuous integration
+
+API Reference
+-------------
+
+.. py:function:: preload_custom_solver_library(library_path, solver_name=None)
+
+   Preload a custom solver library before CasADi imports it.
+
+   :param library_path: Path to the solver library file (str or Path)
+   :param solver_name: Optional solver name for logging (default: derived from filename)
+   :return: True if successful or already loaded from same path; False if already loaded from different path
+   :raises FileNotFoundError: If library file doesn't exist
+   :raises RuntimeError: If library fails to load
+
+   Must be called before importing casadi or any module that imports CasADi.
+
+.. py:function:: check_preload_import_order()
+
+   Check if custom solver preloading was requested but failed due to import order.
+
+   :raises RuntimeError: If preloading was requested but CasADi was already imported
+
+   This function can be called by user code to enforce strict checking of import order
+   when custom solver preloading is critical. By default, RTC-Tools only logs a warning
+   when import order prevents preloading.
+
+.. py:function:: get_solver_library_info(solver_name='highs')
+
+   Get information about which solver library CasADi is using.
+
+   :param solver_name: Name of the solver (e.g., 'highs', 'ipopt', 'bonmin')
+   :return: Dictionary with solver information including paths, versions, and preload status
+   :raises RuntimeError: If called before preloading when RTCTOOLS_PRELOAD_SOLVER_LIBS is set
+
+   .. warning::
+      This function imports CasADi, which prevents any subsequent preloading.
+      Only call this AFTER you've completed any custom solver preloading.
+      If RTCTOOLS_PRELOAD_SOLVER_LIBS is set but CasADi hasn't been imported yet,
+      calling this function will raise RuntimeError to prevent sabotaging the preload.
+
+.. py:data:: RTCTOOLS_PRELOAD_SOLVER_LIBS
+
+   Environment variable for automatic solver preloading.
+
+   **Format:** ``"solver_name:path,solver_name:path,..."``
+
+   **Example:** ``"highs:/opt/highs/lib/libhighs.so,ipopt:/usr/lib/libipopt.so"``
+
+   Processed automatically when rtctools is imported.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -73,7 +73,6 @@ lexicographic goal programming methods, as well as optimization under
 uncertainty using ensemble forecasts.
 
 
-
 Contents
 ========
 
@@ -84,6 +83,7 @@ Contents
    optimization
    simulation
    examples
+   advanced
    related-projects
 
 

--- a/src/rtctools/__init__.py
+++ b/src/rtctools/__init__.py
@@ -1,3 +1,26 @@
+"""
+RTC-Tools: Deltares toolbox for control and optimization of environmental systems.
+
+IMPORTANT: This __init__.py has an intentional import side effect:
+    It checks the RTCTOOLS_PRELOAD_SOLVER_LIBS environment variable and
+    preloads custom solver libraries if specified.
+
+Why this side effect exists:
+    - Custom solver libraries MUST be loaded before CasADi is imported
+    - CasADi is a C extension that cannot be reloaded once imported
+    - This is the only reliable place to intercept imports before CasADi loads
+    - The side effect is opt-in: only occurs if environment variable is set
+
+If RTCTOOLS_PRELOAD_SOLVER_LIBS is not set, this is a no-op.
+
+For more information, see: doc/advanced/custom_solver_versions.rst
+"""
+
+# Preload custom solver libraries if specified in environment
+# This MUST happen before importing any optimization modules that depend on CasADi
+from rtctools.solver_utils import _preload_solvers_from_environment
 from rtctools.version import __version__
+
+_preload_solvers_from_environment()
 
 __all__ = ["__version__"]

--- a/src/rtctools/solver_utils.py
+++ b/src/rtctools/solver_utils.py
@@ -1,0 +1,353 @@
+"""
+Utilities for preloading custom solver libraries with CasADi.
+
+This module provides functionality to use custom versions of solver libraries
+(HiGHS, IPOPT, BONMIN, etc.) instead of those bundled with CasADi.
+
+Architecture:
+    This module uses module-level state (_preloaded_solvers dict) to track which
+    solver libraries have been preloaded. This is necessary because:
+
+    1. Library preloading must happen BEFORE CasADi imports
+    2. CasADi is a C extension that cannot be reloaded
+    3. The preloading decision is process-wide and permanent
+
+    The module-level state is protected by threading.Lock for concurrent access.
+
+Thread Safety:
+    This module uses a threading.Lock to protect access to the _preloaded_solvers
+    dictionary. All public functions are thread-safe for concurrent calls.
+
+    The expensive ctypes.CDLL() operation happens OUTSIDE the lock to allow
+    concurrent library loading by different threads. A double-check pattern is
+    used after loading to handle the race condition where multiple threads try
+    to load the same library simultaneously.
+
+Import Side Effects:
+    When rtctools is imported, this module's _preload_solvers_from_environment()
+    function is automatically called from rtctools.__init__.py. This is an
+    intentional design decision to ensure custom solvers are loaded before CasADi.
+
+    The side effect is opt-in: it only occurs if RTCTOOLS_PRELOAD_SOLVER_LIBS
+    environment variable is set. If not set, the import is a no-op.
+
+Testing Considerations:
+    - Module state persists across test runs in the same process
+    - Tests should clean up _preloaded_solvers in setUp/tearDown
+    - Integration tests require fresh Python processes
+    - See tests/optimization/test_solver_preload.py for examples
+"""
+
+import ctypes
+import logging
+import os
+import sys
+from pathlib import Path
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+# Thread-safe lock for solver preloading operations
+_preload_lock = Lock()
+
+# Track preloaded solvers to avoid duplicates and enforce priority
+# Note: Access to this dict should be protected by _preload_lock in multi-threaded contexts
+_preloaded_solvers: dict[str, Path] = {}
+
+# Track if preloading was requested but failed due to import order
+_preload_failed_due_to_import_order: bool = False
+
+
+def preload_custom_solver_library(library_path: str | Path, solver_name: str | None = None) -> bool:
+    """
+    Preload a custom solver library before CasADi imports it.
+
+    This function allows using custom versions of solver libraries instead of
+    those bundled with CasADi. It must be called BEFORE importing casadi or
+    any rtctools modules that depend on CasADi.
+
+    Currently supported and tested solver: HiGHS.
+    Note: IPOPT preloading does not work with precompiled binaries on Windows - public
+    binaries use incompatible compilers (Intel vs CasADi's GCC/MinGW), and Julia
+    GCC-compiled binaries have missing dependencies. Workaround: use preloading in a
+    Linux environment (e.g., Docker, WSL2) with conda-forge GCC-compiled IPOPT binaries.
+
+    Args:
+        library_path: Path to the custom solver library file
+                     (e.g., libhighs.dll, libipopt.so, etc.)
+        solver_name: Optional solver name for logging purposes (e.g., "HiGHS", "IPOPT")
+
+    Returns:
+        True if library was successfully preloaded or already preloaded from same path.
+        False if already preloaded from a different path (first path takes precedence).
+
+    Raises:
+        FileNotFoundError: If library_path does not exist
+        RuntimeError: If library fails to load
+
+    Example:
+        >>> from rtctools.solver_utils import preload_custom_solver_library
+        >>> # Must be called before any CasADi imports
+        >>> preload_custom_solver_library('/opt/highs-1.12/lib/libhighs.so', 'HiGHS')
+        >>> # Now import optimization modules
+        >>> from rtctools.optimization.optimization_problem import OptimizationProblem
+
+    Environment Variable:
+        Alternatively, set RTCTOOLS_PRELOAD_SOLVER_LIBS environment variable:
+
+        Linux/macOS:
+            export RTCTOOLS_PRELOAD_SOLVER_LIBS="highs:/opt/highs/lib/libhighs.so"
+
+        Windows:
+            set RTCTOOLS_PRELOAD_SOLVER_LIBS=highs:C:/highs/bin/libhighs.dll
+
+        Multiple solvers:
+            export RTCTOOLS_PRELOAD_SOLVER_LIBS="highs:/path/libhighs.so,ipopt:/path/libipopt.so"
+    """
+    library_path = Path(library_path).resolve()
+
+    if not library_path.exists():
+        raise FileNotFoundError(f"Solver library not found: {library_path}")
+
+    if solver_name is None:
+        stem = library_path.stem
+        solver_name = stem[3:] if stem.lower().startswith("lib") else stem
+
+    # Check if already preloaded (with minimal lock time)
+    with _preload_lock:
+        if solver_name in _preloaded_solvers:
+            stored_path = _preloaded_solvers[solver_name]
+            try:
+                same_location = stored_path.samefile(library_path)
+            except FileNotFoundError:
+                # Fall back to direct comparison if filesystem lookup fails
+                same_location = stored_path == library_path
+
+            if same_location:
+                logger.debug(f"{solver_name} already preloaded from: {library_path}")
+                return True
+            else:
+                logger.warning(
+                    f"{solver_name} already preloaded from {_preloaded_solvers[solver_name]}, "
+                    f"ignoring request to load from {library_path}"
+                )
+                return False
+
+    # Load library OUTSIDE the lock to avoid blocking other threads
+    try:
+        logger.info(f"Preloading custom {solver_name} library from: {library_path}")
+
+        if sys.platform.startswith("win"):
+            # Windows: use winmode=0 for proper DLL loading
+            ctypes.CDLL(str(library_path), winmode=0)
+        else:
+            # Linux/macOS: use RTLD_GLOBAL to make symbols available
+            ctypes.CDLL(str(library_path), mode=ctypes.RTLD_GLOBAL)
+
+        # Register the loaded library (acquire lock only for dict update)
+        with _preload_lock:
+            # Double-check: another thread might have loaded it while we were loading
+            if solver_name in _preloaded_solvers:
+                logger.debug(f"{solver_name} was loaded by another thread, using that")
+                return True
+            _preloaded_solvers[solver_name] = library_path.resolve()
+
+        logger.info(f"Successfully preloaded {solver_name} library")
+        return True
+
+    except OSError as e:
+        raise RuntimeError(
+            f"Failed to preload {solver_name} library from {library_path}: {e}\n"
+            f"Common causes:\n"
+            f"  - Missing dependencies (check with ldd/otool/Dependencies.exe)\n"
+            f"  - ABI incompatibility (different compiler or bitness)\n"
+            f"  - Incorrect file path"
+        ) from e
+
+
+def _preload_solvers_from_environment() -> None:
+    """
+    Automatically preload solver libraries specified in environment variable.
+
+    This is called automatically when rtctools is imported.
+
+    Format:
+        RTCTOOLS_PRELOAD_SOLVER_LIBS="solver_name:path,solver_name:path,..."
+
+    Note:
+        This uses ctypes to preload libraries, NOT the OS's library search path.
+        Explicitly preloaded solvers (via preload_custom_solver_library) take
+        precedence over environment variable specifications.
+
+    Important:
+        This only works if called BEFORE casadi is imported. If CasADi is already
+        loaded, a warning will be logged and preloading will be skipped.
+    """
+    global _preload_failed_due_to_import_order
+
+    env_var = os.environ.get("RTCTOOLS_PRELOAD_SOLVER_LIBS", "").strip()
+
+    # Check if CasADi is already imported when preloading is requested
+    if env_var and "casadi" in sys.modules:
+        _preload_failed_due_to_import_order = True
+        logger.warning(
+            "CasADi is already imported. Custom solver preloading via "
+            "RTCTOOLS_PRELOAD_SOLVER_LIBS will have no effect. "
+            "To use custom solver libraries, either:\n"
+            "  1. Set RTCTOOLS_PRELOAD_SOLVER_LIBS before importing any modules, OR\n"
+            "  2. Use preload_custom_solver_library() explicitly before importing CasADi"
+        )
+        return
+
+    if not env_var:
+        return
+
+    logger.debug("Processing RTCTOOLS_PRELOAD_SOLVER_LIBS environment variable")
+
+    # Parse format: "highs:/path/to/libhighs.so,ipopt:/path/to/libipopt.so"
+    for entry in env_var.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+
+        if ":" not in entry:
+            logger.warning(f"Invalid solver preload entry (expected 'name:path'): {entry}")
+            continue
+
+        solver_name, library_path = entry.split(":", 1)
+        solver_name = solver_name.strip()
+        library_path = library_path.strip()
+
+        # Skip if already explicitly preloaded (thread-safe check)
+        with _preload_lock:
+            if solver_name in _preloaded_solvers:
+                logger.debug(
+                    f"{solver_name} already preloaded explicitly, "
+                    f"skipping environment variable entry"
+                )
+                continue
+
+        try:
+            preload_custom_solver_library(library_path, solver_name)
+        except Exception as e:
+            # Log error but don't fail - allow graceful degradation
+            logger.error(f"Failed to preload {solver_name} from environment: {e}")
+
+
+def check_preload_import_order() -> None:
+    """
+    Check if custom solver preloading was requested but failed due to import order.
+
+    This function can be called by user code to enforce strict checking of import order
+    when custom solver preloading is critical. By default, RTC-Tools only logs a warning
+    when import order prevents preloading.
+
+    Raises:
+        RuntimeError: If RTCTOOLS_PRELOAD_SOLVER_LIBS was set but CasADi was already
+                     imported when rtctools attempted preloading (import order violation)
+
+    Example:
+        >>> import os
+        >>> os.environ['RTCTOOLS_PRELOAD_SOLVER_LIBS'] = 'highs:/custom/libhighs.so'
+        >>> from rtctools.solver_utils import check_preload_import_order
+        >>> check_preload_import_order()  # Raises if import order was wrong
+        >>> from rtctools.optimization.optimization_problem import OptimizationProblem
+    """
+    if _preload_failed_due_to_import_order:
+        raise RuntimeError(
+            "Custom solver preloading was requested via RTCTOOLS_PRELOAD_SOLVER_LIBS "
+            "but CasADi was already imported before rtctools could preload the libraries. "
+            "This typically happens when importing rtctools submodules directly.\n\n"
+            "To fix this, ensure you import rtctools (or set the environment variable) "
+            "BEFORE importing any modules that depend on CasADi:\n\n"
+            "Bad:\n"
+            "  from rtctools.optimization.optimization_problem import OptimizationProblem\n"
+            "  # CasADi already loaded, RTCTOOLS_PRELOAD_SOLVER_LIBS ignored\n\n"
+            "Good:\n"
+            "  import rtctools  # Triggers preloading FIRST\n"
+            "  from rtctools.optimization.optimization_problem import OptimizationProblem\n"
+        )
+
+
+def get_solver_library_info(solver_name: str = "highs") -> dict[str, str | Path | int]:
+    """
+    Get information about which solver library CasADi is using.
+
+    **WARNING**: This function imports CasADi, which prevents any subsequent preloading.
+    Only call this AFTER you've completed any custom solver preloading.
+
+    Args:
+        solver_name: Name of the solver (e.g., "highs", "ipopt", "bonmin")
+
+    Returns:
+        Dictionary with keys:
+            - solver: Solver name
+            - casadi_version: CasADi version string
+            - casadi_path: Path to CasADi installation
+            - preloaded: Boolean indicating if custom library was preloaded
+            - preloaded_path: Path to preloaded library (only if preloaded=True)
+            - casadi_bundled_library_path: Path to CasADi's bundled library (if found)
+            - casadi_bundled_library_size: Size of bundled library in bytes (if found)
+
+    Raises:
+        RuntimeError: If called before preloading when RTCTOOLS_PRELOAD_SOLVER_LIBS is set
+
+    Example:
+        >>> from rtctools.solver_utils import preload_custom_solver_library, get_solver_library_info
+        >>> preload_custom_solver_library('/opt/highs/lib/libhighs.so')  # Preload FIRST
+        >>> info = get_solver_library_info('highs')  # Safe to call now
+        >>> print(f"Using HiGHS from: {info.get('preloaded_path', 'CasADi bundled')}")
+    """
+    # Check if user is about to sabotage their own preloading
+    env_var = os.environ.get("RTCTOOLS_PRELOAD_SOLVER_LIBS", "").strip()
+    if env_var and "casadi" not in sys.modules:
+        # User has explicitly requested preloading but hasn't done it yet
+        # Calling this function now would prevent their custom solver from loading
+        raise RuntimeError(
+            f"Cannot call get_solver_library_info() before custom solver preloading completes.\n\n"
+            f"RTCTOOLS_PRELOAD_SOLVER_LIBS is set to: '{env_var}'\n"
+            f"But CasADi has not been imported yet. Calling this function would import CasADi "
+            f"and prevent your custom solver from loading.\n\n"
+            f"To fix this:\n"
+            f"  1. Complete preloading first by importing rtctools or calling "
+            f"preload_custom_solver_library()\n"
+            f"  2. Then call get_solver_library_info() to verify the preload succeeded\n\n"
+            f"Or if you don't actually need custom solvers:\n"
+            f"  1. Unset RTCTOOLS_PRELOAD_SOLVER_LIBS environment variable\n"
+            f"  2. Then call get_solver_library_info()"
+        )
+
+    import casadi as ca
+
+    info = {
+        "solver": solver_name,
+        "casadi_version": ca.__version__,
+        "casadi_path": Path(ca.__file__).parent,
+    }
+
+    # Check if preloaded (thread-safe read)
+    with _preload_lock:
+        if solver_name in _preloaded_solvers:
+            info["preloaded"] = True
+            info["preloaded_path"] = _preloaded_solvers[solver_name]
+        else:
+            info["preloaded"] = False
+
+    # Try to find the library file in CasADi directory
+    casadi_dir = Path(ca.__file__).parent
+
+    if sys.platform.startswith("win"):
+        lib_patterns = [f"lib{solver_name}.dll", f"{solver_name}.dll"]
+    elif sys.platform == "darwin":
+        lib_patterns = [f"lib{solver_name}.dylib", f"lib{solver_name}.so"]
+    else:  # Linux
+        lib_patterns = [f"lib{solver_name}.so"]
+
+    for pattern in lib_patterns:
+        lib_path = casadi_dir / pattern
+        if lib_path.exists():
+            info["casadi_bundled_library_path"] = lib_path
+            info["casadi_bundled_library_size"] = lib_path.stat().st_size
+            break
+
+    return info

--- a/tests/optimization/test_solver_preload.py
+++ b/tests/optimization/test_solver_preload.py
@@ -1,0 +1,573 @@
+"""Tests for custom solver library preloading functionality.
+
+These are UNIT tests that use mocking to test the preloading mechanism.
+
+For INTEGRATION tests that verify actual library loading with CasADi, see:
+    tests/optimization/test_solver_preload_integration.py
+
+Integration tests cannot be part of the pytest suite because:
+1. CasADi is already imported by other tests before these run
+2. Python cannot truly reload C extension modules
+3. Preloading only works BEFORE CasADi's first import in a process
+"""
+
+import ctypes
+import os
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from rtctools.solver_utils import (
+    _preload_solvers_from_environment,
+    check_preload_import_order,
+    get_solver_library_info,
+    preload_custom_solver_library,
+)
+
+from ..test_case import TestCase
+
+
+class TestSolverPreloadExplicit(TestCase):
+    """Test explicit preloading via function calls."""
+
+    def setUp(self) -> None:
+        # Clear any previously preloaded solvers for clean tests
+        import rtctools.solver_utils
+
+        with rtctools.solver_utils._preload_lock:
+            rtctools.solver_utils._preloaded_solvers.clear()
+
+    def test_preload_nonexistent_file(self) -> None:
+        """Test that preloading a nonexistent file raises FileNotFoundError."""
+        with self.assertRaises(FileNotFoundError):
+            preload_custom_solver_library("/nonexistent/path/libhighs.so", "HiGHS")
+
+    @patch("ctypes.CDLL")
+    def test_preload_success_linux(self, mock_cdll) -> None:
+        """Test successful preloading on Linux."""
+        # Create a temporary file to simulate library
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            with patch("sys.platform", "linux"):
+                result = preload_custom_solver_library(tmp_path, "test_solver")
+                self.assertTrue(result)
+                # Verify CDLL was called with RTLD_GLOBAL mode
+                mock_cdll.assert_called_once()
+                call_args = mock_cdll.call_args
+                self.assertIn("mode", call_args[1])
+                self.assertEqual(call_args[1]["mode"], ctypes.RTLD_GLOBAL)
+        finally:
+            os.unlink(tmp_path)
+
+    @patch("ctypes.CDLL")
+    def test_preload_success_windows(self, mock_cdll) -> None:
+        """Test successful preloading on Windows."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".dll", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            with patch("sys.platform", "win32"):
+                result = preload_custom_solver_library(tmp_path, "test_solver")
+                self.assertTrue(result)
+                # Verify CDLL was called with winmode=0
+                mock_cdll.assert_called_once()
+                call_args = mock_cdll.call_args
+                self.assertEqual(call_args[1]["winmode"], 0)
+        finally:
+            os.unlink(tmp_path)
+
+    @patch("ctypes.CDLL")
+    def test_preload_duplicate(self, mock_cdll) -> None:
+        """Test that duplicate preloading is handled correctly."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            # First preload
+            result1 = preload_custom_solver_library(tmp_path, "test_solver")
+            self.assertTrue(result1)
+
+            # Second preload of same library - should return True without re-loading
+            result2 = preload_custom_solver_library(tmp_path, "test_solver")
+            self.assertTrue(result2)
+            # CDLL should only be called once
+            self.assertEqual(mock_cdll.call_count, 1)
+        finally:
+            os.unlink(tmp_path)
+
+    @patch("ctypes.CDLL")
+    def test_preload_different_paths_same_solver(self, mock_cdll) -> None:
+        """Test that preloading from different paths for same solver name is rejected."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path1 = Path(tmpdir) / "lib1.so"
+            tmp_path2 = Path(tmpdir) / "lib2.so"
+            tmp_path1.touch()
+            tmp_path2.touch()
+
+            # First preload
+            result1 = preload_custom_solver_library(tmp_path1, "test_solver")
+            self.assertTrue(result1)
+
+            # Second preload from different path - should be rejected
+            result2 = preload_custom_solver_library(tmp_path2, "test_solver")
+            self.assertFalse(result2)
+            # CDLL should only be called once
+            self.assertEqual(mock_cdll.call_count, 1)
+
+    @patch("ctypes.CDLL", side_effect=OSError("Mock load failure"))
+    def test_preload_failure(self, mock_cdll) -> None:
+        """Test that loading failure raises RuntimeError with helpful message."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            with self.assertRaises(RuntimeError) as context:
+                preload_custom_solver_library(tmp_path, "test_solver")
+
+            # Check error message contains helpful information
+            error_msg = str(context.exception)
+            self.assertIn("Failed to preload", error_msg)
+            self.assertIn("Common causes", error_msg)
+            self.assertIn("dependencies", error_msg.lower())
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestSolverPreloadEnvironment(TestCase):
+    """Test automatic preloading via environment variable."""
+
+    def setUp(self) -> None:
+        # Clear any previously preloaded solvers
+        import rtctools.solver_utils
+
+        with rtctools.solver_utils._preload_lock:
+            rtctools.solver_utils._preloaded_solvers.clear()
+        # Clear environment variable
+        if "RTCTOOLS_PRELOAD_SOLVER_LIBS" in os.environ:
+            del os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"]
+
+    def tearDown(self) -> None:
+        # Clean up environment
+        if "RTCTOOLS_PRELOAD_SOLVER_LIBS" in os.environ:
+            del os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"]
+
+    def test_no_environment_variable(self) -> None:
+        """Test that nothing happens when environment variable is not set."""
+        _preload_solvers_from_environment()
+        import rtctools.solver_utils
+
+        self.assertEqual(len(rtctools.solver_utils._preloaded_solvers), 0)
+
+    def test_empty_environment_variable(self) -> None:
+        """Test that empty environment variable is handled gracefully."""
+        os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"] = ""
+        _preload_solvers_from_environment()
+        import rtctools.solver_utils
+
+        self.assertEqual(len(rtctools.solver_utils._preloaded_solvers), 0)
+
+    @patch("ctypes.CDLL")
+    @patch.dict("sys.modules", {"casadi": None}, clear=False)
+    def test_single_solver_from_environment(self, mock_cdll) -> None:
+        """Test loading a single solver from environment variable."""
+        import tempfile
+
+        # Remove casadi from sys.modules to simulate fresh import
+        sys.modules.pop("casadi", None)
+
+        with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"] = f"test_solver:{tmp_path}"
+            _preload_solvers_from_environment()
+
+            import rtctools.solver_utils
+
+            self.assertIn("test_solver", rtctools.solver_utils._preloaded_solvers)
+            mock_cdll.assert_called_once()
+        finally:
+            os.unlink(tmp_path)
+
+    @patch("ctypes.CDLL")
+    @patch.dict("sys.modules", {"casadi": None}, clear=False)
+    def test_multiple_solvers_from_environment(self, mock_cdll) -> None:
+        """Test loading multiple solvers from environment variable."""
+        import tempfile
+
+        # Remove casadi from sys.modules to simulate fresh import
+        sys.modules.pop("casadi", None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path1 = Path(tmpdir) / "lib1.so"
+            tmp_path2 = Path(tmpdir) / "lib2.so"
+            tmp_path1.touch()
+            tmp_path2.touch()
+
+            os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"] = f"solver1:{tmp_path1},solver2:{tmp_path2}"
+            _preload_solvers_from_environment()
+
+            import rtctools.solver_utils
+
+            self.assertIn("solver1", rtctools.solver_utils._preloaded_solvers)
+            self.assertIn("solver2", rtctools.solver_utils._preloaded_solvers)
+            self.assertEqual(mock_cdll.call_count, 2)
+
+    def test_invalid_format(self) -> None:
+        """Test that invalid format is logged but doesn't crash."""
+        os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"] = "invalid_no_colon"
+        # Should not raise exception
+        _preload_solvers_from_environment()
+
+        import rtctools.solver_utils
+
+        self.assertEqual(len(rtctools.solver_utils._preloaded_solvers), 0)
+
+    @patch("ctypes.CDLL")
+    def test_explicit_preload_takes_precedence(self, mock_cdll) -> None:
+        """Test that explicit preloading takes precedence over environment variable."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path1 = Path(tmpdir) / "lib1.so"
+            tmp_path2 = Path(tmpdir) / "lib2.so"
+            tmp_path1.touch()
+            tmp_path2.touch()
+
+            # Explicit preload first
+            preload_custom_solver_library(tmp_path1, "test_solver")
+
+            # Set environment variable with different path
+            os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"] = f"test_solver:{tmp_path2}"
+            _preload_solvers_from_environment()
+
+            import rtctools.solver_utils
+
+            # Should still be using the explicitly preloaded path
+            self.assertEqual(
+                Path(rtctools.solver_utils._preloaded_solvers["test_solver"]).resolve(),
+                tmp_path1.resolve(),
+            )
+            # CDLL should only be called once (for explicit preload)
+            self.assertEqual(mock_cdll.call_count, 1)
+
+    def test_nonexistent_file_from_environment(self) -> None:
+        """Test that nonexistent file from environment is logged but doesn't crash."""
+        os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"] = "test_solver:/nonexistent/path.so"
+        # Should not raise exception (graceful degradation)
+        _preload_solvers_from_environment()
+
+        import rtctools.solver_utils
+
+        self.assertEqual(len(rtctools.solver_utils._preloaded_solvers), 0)
+
+
+class TestImportOrderGuard(TestCase):
+    """Test import order detection and guard function."""
+
+    def setUp(self) -> None:
+        # Clear any previously preloaded solvers
+        import rtctools.solver_utils
+
+        with rtctools.solver_utils._preload_lock:
+            rtctools.solver_utils._preloaded_solvers.clear()
+            rtctools.solver_utils._preload_failed_due_to_import_order = False
+        # Clear environment variable
+        if "RTCTOOLS_PRELOAD_SOLVER_LIBS" in os.environ:
+            del os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"]
+
+    def tearDown(self) -> None:
+        # Clean up
+        import rtctools.solver_utils
+
+        with rtctools.solver_utils._preload_lock:
+            rtctools.solver_utils._preload_failed_due_to_import_order = False
+        if "RTCTOOLS_PRELOAD_SOLVER_LIBS" in os.environ:
+            del os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"]
+
+    def test_check_preload_import_order_success(self) -> None:
+        """Test that check passes when no import order issue."""
+        # Should not raise
+        check_preload_import_order()
+
+    def test_check_preload_import_order_failure(self) -> None:
+        """Test that check raises when import order is wrong."""
+        import rtctools.solver_utils
+
+        # Simulate failed preload due to import order
+        with rtctools.solver_utils._preload_lock:
+            rtctools.solver_utils._preload_failed_due_to_import_order = True
+
+        with self.assertRaises(RuntimeError) as context:
+            check_preload_import_order()
+
+        error_msg = str(context.exception)
+        self.assertIn("Custom solver preloading was requested", error_msg)
+        self.assertIn("CasADi was already imported", error_msg)
+        self.assertIn("import", error_msg.lower())
+
+    def test_preload_from_environment_sets_flag_on_casadi_already_imported(self) -> None:
+        """Test that flag is set when CasADi is already imported."""
+        import rtctools.solver_utils
+
+        # Set environment variable
+        os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"] = "highs:/fake/path.so"
+
+        # Simulate CasADi already being imported
+        sys.modules["casadi"] = MagicMock()
+
+        try:
+            _preload_solvers_from_environment()
+
+            # Flag should be set
+            self.assertTrue(rtctools.solver_utils._preload_failed_due_to_import_order)
+
+            # check_preload_import_order should now raise
+            with self.assertRaises(RuntimeError):
+                check_preload_import_order()
+        finally:
+            # Clean up fake casadi module
+            del sys.modules["casadi"]
+
+
+class TestSolverLibraryInfo(TestCase):
+    """Test diagnostic utility for getting solver library information."""
+
+    def setUp(self) -> None:
+        # Clear environment variable
+        if "RTCTOOLS_PRELOAD_SOLVER_LIBS" in os.environ:
+            del os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"]
+
+    def tearDown(self) -> None:
+        # Clean up
+        if "RTCTOOLS_PRELOAD_SOLVER_LIBS" in os.environ:
+            del os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"]
+
+    def test_get_highs_info(self) -> None:
+        """Test getting HiGHS library information."""
+        info = get_solver_library_info("highs")
+
+        # Check required keys
+        self.assertIn("solver", info)
+        self.assertIn("casadi_version", info)
+        self.assertIn("casadi_path", info)
+        self.assertIn("preloaded", info)
+
+        self.assertEqual(info["solver"], "highs")
+        self.assertIsInstance(info["preloaded"], bool)
+
+    def test_get_info_raises_if_called_before_env_var_preload(self) -> None:
+        """Test that calling get_solver_library_info before preloading raises error."""
+        # Set environment variable
+        os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"] = "highs:/fake/path.so"
+
+        # Simulate casadi NOT being imported yet
+        casadi_was_imported = "casadi" in sys.modules
+        if casadi_was_imported:
+            # Can't test this scenario in this test run since casadi is already loaded
+            # This would only trigger in a fresh Python process
+            self.skipTest("CasADi already imported - can't test pre-import error")
+
+        # Should raise RuntimeError to prevent sabotaging preload
+        with self.assertRaises(RuntimeError) as context:
+            get_solver_library_info("highs")
+
+        error_msg = str(context.exception)
+        self.assertIn("Cannot call get_solver_library_info()", error_msg)
+        self.assertIn("RTCTOOLS_PRELOAD_SOLVER_LIBS is set", error_msg)
+        self.assertIn("prevent your custom solver from loading", error_msg)
+
+    def test_get_info_for_unknown_solver(self) -> None:
+        """Test getting info for a solver that doesn't exist."""
+        info = get_solver_library_info("nonexistent_solver")
+
+        # Should still return basic info
+        self.assertIn("solver", info)
+        self.assertIn("casadi_version", info)
+        self.assertEqual(info["solver"], "nonexistent_solver")
+        # Should not have library_path since it doesn't exist
+        self.assertNotIn("casadi_bundled_library_path", info)
+
+    @patch("ctypes.CDLL")
+    def test_get_info_after_preload(self, mock_cdll) -> None:
+        """Test that info reflects preloaded library."""
+        import tempfile
+
+        import rtctools.solver_utils
+
+        with rtctools.solver_utils._preload_lock:
+            rtctools.solver_utils._preloaded_solvers.clear()
+
+        with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            preload_custom_solver_library(tmp_path, "test_solver")
+            info = get_solver_library_info("test_solver")
+
+            self.assertTrue(info["preloaded"])
+            self.assertEqual(info["preloaded_path"], Path(tmp_path))
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestThreadSafety(TestCase):
+    """Test thread-safety of preloading operations."""
+
+    def setUp(self) -> None:
+        # Clear any previously preloaded solvers
+        import rtctools.solver_utils
+
+        with rtctools.solver_utils._preload_lock:
+            rtctools.solver_utils._preloaded_solvers.clear()
+
+    @patch("ctypes.CDLL")
+    def test_concurrent_preload_same_library(self, mock_cdll) -> None:
+        """Test that concurrent preloads of the same library are handled safely."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            results = []
+            errors = []
+
+            def preload_worker():
+                try:
+                    result = preload_custom_solver_library(tmp_path, "test_solver")
+                    results.append(result)
+                except Exception as e:
+                    errors.append(e)
+
+            # Launch 5 threads trying to preload the same library
+            threads = [threading.Thread(target=preload_worker) for _ in range(5)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            # No errors should occur
+            self.assertEqual(len(errors), 0)
+
+            # All threads should succeed (first gets True, rest get True from duplicate check)
+            self.assertEqual(len(results), 5)
+            self.assertTrue(all(results))
+
+            # CDLL should only be called once (first thread wins)
+            self.assertEqual(mock_cdll.call_count, 1)
+        finally:
+            os.unlink(tmp_path)
+
+    @patch("ctypes.CDLL")
+    def test_concurrent_preload_different_libraries(self, mock_cdll) -> None:
+        """Test that concurrent preloads of different libraries work correctly."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create multiple temp files
+            temp_files = []
+            for i in range(3):
+                tmp_path = Path(tmpdir) / f"lib{i}.so"
+                tmp_path.touch()
+                temp_files.append((str(tmp_path), f"solver_{i}"))
+
+            results = {}
+            errors = []
+
+            def preload_worker(path, name):
+                try:
+                    result = preload_custom_solver_library(path, name)
+                    results[name] = result
+                except Exception as e:
+                    errors.append(e)
+
+            # Launch threads for different solvers
+            threads = [
+                threading.Thread(target=preload_worker, args=(path, name))
+                for path, name in temp_files
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            # No errors should occur
+            self.assertEqual(len(errors), 0)
+
+            # All solvers should be preloaded successfully
+            self.assertEqual(len(results), 3)
+            self.assertTrue(all(results.values()))
+
+            # CDLL should be called once per solver
+            self.assertEqual(mock_cdll.call_count, 3)
+
+
+class TestRealHiGHSPreload(TestCase):
+    """Integration test with real HiGHS 1.12.0 library.
+
+    Note: This test is skipped by default because the MSYS2 HiGHS 1.12.0 library
+    has missing dependencies (libgcc, libstdc++, etc.) that cause load failures.
+    This is expected behavior and was documented during our investigation.
+
+    The test exists to document the expected behavior and can be enabled
+    when a properly bundled HiGHS library (with all dependencies) is available.
+
+    Environment Variables:
+        TEST_HIGHS_LIBRARY_PATH: Optional path to custom HiGHS library for testing.
+                                If not set, uses platform-specific default under test_highs_custom/
+    """
+
+    def setUp(self) -> None:
+        # Path to the extracted HiGHS 1.12.0 library
+        # Can be overridden with TEST_HIGHS_LIBRARY_PATH environment variable
+        custom_path = os.environ.get("TEST_HIGHS_LIBRARY_PATH")
+        if custom_path:
+            self.custom_highs_path = Path(custom_path)
+        else:
+            # Platform-specific default path
+            base_dir = Path(__file__).parent.parent.parent / "test_highs_custom"
+            if sys.platform.startswith("win"):
+                self.custom_highs_path = base_dir / "mingw64" / "bin" / "libhighs.dll"
+            elif sys.platform == "darwin":
+                self.custom_highs_path = base_dir / "macos" / "lib" / "libhighs.dylib"
+            else:
+                self.custom_highs_path = base_dir / "linux" / "lib" / "libhighs.so"
+
+    @unittest.skip("MSYS2 HiGHS 1.12.0 has missing dependencies - expected failure")
+    def test_real_highs_preload(self) -> None:
+        """Test preloading actual HiGHS 1.12.0 library.
+
+        This test is skipped because the MSYS2-built HiGHS requires MinGW runtime
+        DLLs (libgcc, libstdc++, libwinpthread) which are not bundled.
+
+        To make this test pass, users would need to:
+        1. Use a statically-linked HiGHS build, OR
+        2. Ensure MinGW runtime DLLs are in PATH, OR
+        3. Extract all dependencies from the MSYS2 package
+        """
+        if not self.custom_highs_path.exists():
+            self.skipTest(f"Custom HiGHS library not found at {self.custom_highs_path}")
+
+        # This will raise RuntimeError due to missing dependencies
+        with self.assertRaises(RuntimeError) as context:
+            preload_custom_solver_library(str(self.custom_highs_path), "HiGHS")
+
+        # Verify error message is helpful
+        error_msg = str(context.exception)
+        self.assertIn("Failed to preload", error_msg)
+        self.assertIn("dependencies", error_msg.lower())

--- a/tests/optimization/test_solver_preload_integration.py
+++ b/tests/optimization/test_solver_preload_integration.py
@@ -1,0 +1,186 @@
+"""
+Integration test for custom solver preloading.
+
+IMPORTANT: This test CANNOT be run as part of the normal pytest suite because:
+1. CasADi is already imported by other tests before this runs
+2. Python cannot truly reload C extension modules
+3. Preloading only works BEFORE CasADi's first import
+
+This script must be run in a fresh Python process:
+
+    python tests/optimization/test_solver_preload_integration.py
+
+Environment Variables:
+    TEST_HIGHS_LIBRARY_PATH: Optional path to custom HiGHS library for testing.
+                            If not set, uses platform-specific default under test_highs_custom/
+
+The test verifies that:
+1. Custom solver library is successfully preloaded
+2. CasADi uses the preloaded library instead of its bundled version
+3. Solver version matches the custom library version
+"""
+
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+
+def test_explicit_preload():
+    """Test explicit preloading before CasADi import."""
+    print("\n=== Test 1: Explicit Preloading ===")
+
+    # Verify CasADi not yet imported
+    if "casadi" in sys.modules:
+        print("[FAIL] CasADi already imported - cannot test preloading")
+        return False
+
+    import os
+
+    from rtctools.solver_utils import get_solver_library_info, preload_custom_solver_library
+
+    # Path to custom HiGHS library (you need to provide a real library for this test)
+    # Can be overridden with TEST_HIGHS_LIBRARY_PATH environment variable
+    custom_path = os.environ.get("TEST_HIGHS_LIBRARY_PATH")
+    if custom_path:
+        custom_highs_path = Path(custom_path)
+    else:
+        # Platform-specific default path
+        base_dir = Path(__file__).parent.parent.parent / "test_highs_custom"
+        if sys.platform.startswith("win"):
+            custom_highs_path = base_dir / "mingw64" / "bin" / "libhighs.dll"
+        elif sys.platform == "darwin":
+            custom_highs_path = base_dir / "macos" / "lib" / "libhighs.dylib"
+        else:
+            custom_highs_path = base_dir / "linux" / "lib" / "libhighs.so"
+
+    if not custom_highs_path.exists():
+        print(f"[SKIP] Custom HiGHS library not found at {custom_highs_path}")
+        print("       This test requires a real HiGHS library to verify integration")
+        return None  # Skip
+
+    try:
+        # Preload custom library
+        print(f"Preloading custom HiGHS from: {custom_highs_path}")
+        success = preload_custom_solver_library(str(custom_highs_path), "highs")
+
+        if not success:
+            print("[FAIL] preload_custom_solver_library() returned False")
+            return False
+
+        print("[OK] Preload succeeded")
+
+        # Now import CasADi and verify
+        print("Importing CasADi...")
+        import casadi as ca
+
+        print(f"CasADi version: {ca.__version__}")
+
+        # Get solver info
+        info = get_solver_library_info("highs")
+        print(f"Preloaded: {info['preloaded']}")
+
+        if info["preloaded"]:
+            print(f"Custom library path: {info['preloaded_path']}")
+            print("[OK] Custom HiGHS was preloaded")
+
+            # Verify the path matches
+            if Path(info["preloaded_path"]).samefile(custom_highs_path):
+                print("[OK] Preloaded path matches expected path")
+                return True
+            else:
+                print(f"[FAIL] Path mismatch: {info['preloaded_path']} != {custom_highs_path}")
+                return False
+        else:
+            print("[FAIL] HiGHS was not preloaded")
+            return False
+
+    except Exception as e:
+        print(f"[FAIL] Exception: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_environment_variable_preload():
+    """Test environment variable preloading.
+
+    This would need to be run in a separate process with env var set before importing rtctools.
+    """
+    print("\n=== Test 2: Environment Variable Preloading ===")
+    print(
+        "[SKIP] This test requires running in a fresh process with RTCTOOLS_PRELOAD_SOLVER_LIBS set"
+    )
+    print("       Example:")
+    print("           set RTCTOOLS_PRELOAD_SOLVER_LIBS=highs:C:\\path\\to\\libhighs.dll")
+    print(
+        '           python -c "import rtctools; from rtctools.solver_utils import '
+        "get_solver_library_info; print(get_solver_library_info('highs'))\""
+    )
+    return None
+
+
+def test_defensive_checks():
+    """Test that defensive checks work correctly."""
+    print("\n=== Test 3: Defensive Checks ===")
+
+    # This test can only run if CasADi is already imported
+    if "casadi" not in sys.modules:
+        print("[SKIP] CasADi not imported - can't test defensive checks")
+        return None
+
+    import os
+
+    from rtctools.solver_utils import get_solver_library_info
+
+    # Test 1: get_solver_library_info with env var set should raise
+    os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"] = "highs:/fake/path.so"
+
+    try:
+        # Since CasADi is already imported, this should NOT raise
+        _ = get_solver_library_info("highs")
+        print("[OK] get_solver_library_info() works when CasADi already imported")
+    except RuntimeError as e:
+        print(f"[FAIL] Unexpected RuntimeError: {e}")
+        return False
+    finally:
+        del os.environ["RTCTOOLS_PRELOAD_SOLVER_LIBS"]
+
+    return True
+
+
+if __name__ == "__main__":
+    print("=" * 70)
+    print("Custom Solver Preloading Integration Tests")
+    print("=" * 70)
+    print()
+    print("NOTE: These tests verify actual library preloading behavior.")
+    print("      Some tests may be skipped if custom libraries are not available.")
+    print()
+
+    results = []
+
+    # Run tests
+    results.append(("Explicit Preload", test_explicit_preload()))
+    results.append(("Environment Variable", test_environment_variable_preload()))
+    results.append(("Defensive Checks", test_defensive_checks()))
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("Test Summary")
+    print("=" * 70)
+
+    passed = sum(1 for _, result in results if result is True)
+    failed = sum(1 for _, result in results if result is False)
+    skipped = sum(1 for _, result in results if result is None)
+
+    for name, result in results:
+        status = "PASS" if result is True else "FAIL" if result is False else "SKIP"
+        print(f"  {name:30s} {status}")
+
+    print()
+    print(f"Total: {passed} passed, {failed} failed, {skipped} skipped")
+
+    sys.exit(0 if failed == 0 else 1)


### PR DESCRIPTION
Implement mechanism to use custom versions of solver libraries instead of those bundled with CasADi. This enables users to leverage newer solver versions, apply patches, or use optimized builds.

Core implementation:
- Add solver_utils.py with thread-safe preloading via ctypes.CDLL
- Support explicit preloading and environment variable (RTCTOOLS_PRELOAD_SOLVER_LIBS)
- Automatic preloading on rtctools import when env var is set
- Import order validation and diagnostic utilities

Features:
- Platform-specific handling (RTLD_GLOBAL on Unix, winmode=0 on Windows)
- Thread-safe with optimized lock pattern (CDLL loading outside lock)
- Graceful degradation when preloading fails
- Comprehensive error messages with troubleshooting guidance

Testing:
- Currently supported and tested: HiGHS
- Comprehensive unit tests
- Separate integration test script for fresh-process testing
- Thread-safety tests covering concurrent preloading scenarios
- Configurable test library paths

Documentation:
- Complete user guide in doc/advanced/custom_solver_versions.rst
- Platform-specific instructions (Linux, macOS, Windows)
- Troubleshooting section with common issues
- Explicit IPOPT Windows limitation documented
- API reference with usage examples

Code quality improvements:
- Module-specific logger (__name__) for better filtering
- Simplified docstring examples
- Documented architecture and design decisions