### PR TITLE
optimization: Add LP file export for linear problems

### DIFF
--- a/src/rtctools/_internal/casadi_to_lp.py
+++ b/src/rtctools/_internal/casadi_to_lp.py
@@ -1,0 +1,424 @@
+import logging
+import os
+import textwrap
+
+import casadi as ca
+import numpy as np
+
+# The LP file format limits line length to 255 characters.
+LP_MAX_LINE_WIDTH = 255
+
+# Threshold for treating coefficients and constants as zero (absorbs floating-point noise)
+LP_COEFF_EPSILON = 1e-10
+
+# Tolerance for testing whether a constant constraint row satisfies its bounds. Kept
+# separate from LP_COEFF_EPSILON (a coefficient-magnitude threshold) because this absorbs
+# floating-point noise in a scalar value-vs-bound comparison, a distinct concern.
+LP_FEASIBILITY_EPSILON = 1e-9
+
+logger = logging.getLogger("rtctools")
+
+# Note: the LP file is currently used for diagnostics/export only. Using it as a
+# solve path — by passing the problem as an in-memory data structure directly to
+# the solver (bypassing CasADi's solver interface) — would unlock solver-native
+# capabilities such as hierarchical multi-objective optimization (goal programming)
+# and lazy constraints with separation oracle callbacks.
+
+# The LP format supports several sections not currently implemented here:
+#   - Lazy Constraints: hints to the solver that constraints can be added lazily
+#   - User Cuts: cutting planes supplied by the user
+#   - SOS: special ordered sets (type 1 and 2)
+#   - Semi-continuous / Semi-integer: variables that are either zero or within a range
+#   - PWLObj: piecewise-linear objective functions
+#   - General Constraints: MIN, MAX, ABS, OR, AND, NORM, PWL function constraints
+#   - Scenarios: multiple scenario data (objective/constraint/bound changes per scenario)
+#   - Multi-objective: weighted/hierarchical objective sections
+# See https://docs.gurobi.com/projects/optimizer/en/current/reference/fileformats/modelformats.html#lp-format
+
+
+def _format_lp_bound(val: float) -> str:
+    """Format a bound value as an LP-standard string.
+
+    Uses +Inf / -Inf for infinite values (CPLEX LP standard).
+    Finite values use :.15g formatting, which avoids Python scientific
+    notation while keeping approximately full float precision
+    (~15 significant digits).
+    """
+    if np.isposinf(val):
+        return "+Inf"
+    if np.isneginf(val):
+        return "-Inf"
+    return f"{val:.15g}"
+
+
+def _build_objective(f: ca.SX, x: ca.SX, var_names: list[str]) -> str:
+    """
+    Build the LP objective string from the symbolic objective and variable names.
+
+    The objective is wrapped to respect the LP format 255-character line limit,
+    but only at whitespace boundaries to preserve variable names and coefficients.
+
+    Args:
+        f: Symbolic objective expression (scalar, affine in x).
+        x: Decision variable vector (length must match var_names).
+        var_names: Human-readable name for each element of x.
+
+    Returns:
+        Indented, line-wrapped objective function string ready to follow
+        the ``Minimize`` header in an LP file.
+    """
+    A, b = ca.linear_coeff(f, x)
+    A = ca.DM(A)
+    b = ca.DM(b)
+
+    ind = np.array(A)[0, :]
+    objective = []
+    for v, c in zip(var_names, ind, strict=True):
+        if abs(c) > LP_COEFF_EPSILON:
+            objective.extend(["+" if c > 0 else "-", f"{abs(c):.15g}", v])
+    # Add constant term
+    b_val = float(b)
+    if abs(b_val) > LP_COEFF_EPSILON:
+        objective.extend(["+" if b_val > 0 else "-", f"{abs(b_val):.15g}"])
+
+    # Remove leading sign: "+" is invalid as a leading token;
+    # "-" becomes a unary minus by merging it with the following value.
+    if objective and objective[0] == "+":
+        objective.pop(0)
+    elif objective and objective[0] == "-":
+        objective[1] = "-" + objective[1]
+        objective.pop(0)
+
+    objective_str = " ".join(objective)
+    # Emit an explicit zero objective when all terms are below epsilon threshold;
+    # some LP parsers reject a blank objective line after "Minimize".
+    if not objective_str:
+        objective_str = "0"
+    # Wrap at word boundaries only (spaces), never breaking tokens like variable names
+    wrapped_objective = "\n".join(
+        textwrap.wrap(
+            "  " + objective_str,
+            width=LP_MAX_LINE_WIDTH,
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+    )
+    return wrapped_objective
+
+
+def _build_constraints(
+    g: ca.SX,
+    x: ca.SX,
+    lbg: list,
+    ubg: list,
+    var_names: list[str],
+) -> str:
+    """
+    Build the LP constraints string.
+
+    Each constraint row ``g[i]`` is written as one or two inequality/equality
+    lines depending on its bounds.  Range constraints (finite lb and ub, lb != ub)
+    are split into two separate inequalities; the LP ``Ranges`` section is not used.
+
+    Note: constraint lines are not wrapped and may exceed the LP format 255-character
+    line limit for problems with many variables. Use shorter variable names if needed.
+
+    Args:
+        g: Symbolic constraint vector (affine in x).
+        x: Decision variable vector (length must match var_names).
+        lbg: Lower bounds on each constraint row (``-inf`` for one-sided upper bounds).
+        ubg: Upper bounds on each constraint row (``+inf`` for one-sided lower bounds).
+        var_names: Human-readable name for each element of x.
+
+    Returns:
+        Indented constraints string ready to follow the ``Subject To`` header
+        in an LP file.
+
+    Raises:
+        ValueError: If a constraint row has no variable terms and its constant value
+            violates its bounds, i.e. the problem is infeasible.
+    """
+    A, b = ca.linear_coeff(g, x)
+    A = ca.sparsify(ca.DM(A))
+    b = ca.DM(b)
+
+    lbg = np.array(ca.veccat(*lbg))[:, 0]
+    ubg = np.array(ca.veccat(*ubg))[:, 0]
+    A_csc = A.tocsc()
+    A_coo = A_csc.tocoo()
+    b = np.array(b)[:, 0]
+
+    constraints = [[] for _ in range(A.shape[0])]
+    for i, j, c in zip(A_coo.row, A_coo.col, A_coo.data, strict=True):
+        if abs(c) > LP_COEFF_EPSILON:
+            constraints[i].extend(["+" if c > 0 else "-", f"{abs(c):.15g}", var_names[j]])
+
+    constraints_str_list = []
+    for i, cur_constr in enumerate(constraints):
+        lb, ub, b_i = lbg[i], ubg[i], b[i]
+        if cur_constr:
+            if cur_constr[0] == "-":
+                cur_constr[1] = "-" + cur_constr[1]
+            cur_constr.pop(0)
+        c_str = " ".join(cur_constr)
+
+        if not c_str:
+            # Row has no variable terms: it reduces to the constant b_i. The LP format
+            # requires a variable term per row (a literal "0 = 0" is rejected by e.g.
+            # CPLEX). Current behavior: a feasible constant row (within bounds) is dropped;
+            # an infeasible one is the source of the model's infeasibility and must not be
+            # dropped (that would make the exported file feasible while the model is not),
+            # so we raise.
+            # TODO(RTCTOOLS-1512): instead of raising on an infeasible constant row,
+            # preserve it via a dummy variable fixed to 1 so an external solver reproduces
+            # the infeasibility during presolve.
+            lb_ok = (not np.isfinite(lb)) or b_i >= lb - LP_FEASIBILITY_EPSILON
+            ub_ok = (not np.isfinite(ub)) or b_i <= ub + LP_FEASIBILITY_EPSILON
+            if lb_ok and ub_ok:
+                continue
+            side = "lower bound" if not lb_ok else "upper bound"
+            raise ValueError(
+                f"Violated constraint {i}: it reduces to the constant {b_i:.15g}, which "
+                f"violates its {side} (bounds [{_format_lp_bound(lb)}, {_format_lp_bound(ub)}]). "
+                f"The problem is infeasible."
+            )
+
+        if np.isfinite(lb) and np.isfinite(ub) and lb == ub:
+            constraint_line = f"{c_str} = {lb - b_i:.15g}"
+        elif np.isfinite(lb) and np.isfinite(ub):
+            # Range constraint: lb <= expr <= ub. We do not use the LP ``Ranges``
+            # section; we express this as two separate inequalities instead.
+            constraints_str_list.append(f"{c_str} >= {lb - b_i:.15g}")
+            constraint_line = f"{c_str} <= {ub - b_i:.15g}"
+        elif np.isfinite(lb):
+            constraint_line = f"{c_str} >= {lb - b_i:.15g}"
+        elif np.isfinite(ub):
+            constraint_line = f"{c_str} <= {ub - b_i:.15g}"
+        else:
+            logger.warning(
+                "Constraint %d has no finite bound (lbg=%s, ubg=%s, b_i=%s). "
+                "Writing as '<= +Inf' for debugging; this constraint is vacuous.",
+                i,
+                lb,
+                ub,
+                b_i,
+            )
+            constraint_line = f"{c_str} <= {_format_lp_bound(ub)}"
+        constraints_str_list.append(constraint_line)
+    if not constraints_str_list:
+        # Every row was a skipped feasible constant: there are no constraints to write.
+        return ""
+    return "  " + "\n  ".join(constraints_str_list)
+
+
+def _build_bounds(
+    var_names: list[str], lbx: list, ubx: list, discrete: list[bool]
+) -> tuple[str, list[str], list[str]]:
+    """
+    Build the LP bounds string and classify discrete variables.
+
+    Binary variables (discrete with bounds [0, 1]) are omitted from the Bounds
+    section because the LP ``Binary`` section implicitly defines their bounds.
+
+    Canonical bound forms emitted:
+    - Both infinite: ``name Free``
+    - Lower bound only: ``lb <= name``
+    - Upper bound only: ``name <= ub``
+    - Both finite: ``lb <= name <= ub``
+
+    Args:
+        var_names: Human-readable name for each variable.
+        lbx: Lower bounds on variables (``-inf`` for unbounded below).
+        ubx: Upper bounds on variables (``+inf`` for unbounded above).
+        discrete: ``True`` for each variable that must take integer values.
+
+    Returns:
+        Tuple ``(bounds_str, binary_vars, general_vars)`` where ``bounds_str``
+        is the indented bounds section (empty string when nothing to emit),
+        ``binary_vars`` is the list of binary (0/1) variable names, and
+        ``general_vars`` is the list of general integer variable names.
+    """
+    bounds_list = []
+    binary_vars = []
+    general_vars = []
+    for v, lb, ub, is_discrete in zip(var_names, lbx, ubx, discrete, strict=True):
+        if is_discrete:
+            if lb == 0 and ub == 1:
+                binary_vars.append(v)
+                continue  # Binary section implicitly bounds these to [0, 1]
+            else:
+                general_vars.append(v)
+        if not np.isfinite(lb) and not np.isfinite(ub):
+            bounds_list.append(f"{v} Free")
+        elif not np.isfinite(lb):
+            bounds_list.append(f"{v} <= {_format_lp_bound(ub)}")
+        elif not np.isfinite(ub):
+            bounds_list.append(f"{_format_lp_bound(lb)} <= {v}")
+        else:
+            bounds_list.append(f"{_format_lp_bound(lb)} <= {v} <= {_format_lp_bound(ub)}")
+    bounds_str = "\n  ".join(bounds_list)
+    return ("  " + bounds_str) if bounds_str else "", binary_vars, general_vars
+
+
+def _sanitize_var_names(
+    indices_per_member: list[dict[str, list[int]]], num_total: int
+) -> list[str]:
+    """
+    Build LP-compatible variable names for every slot in the combined decision vector.
+
+    A variable is *shared* when every ensemble member maps it to the exact same
+    slot indices.  Shared variables receive no member suffix; per-member variables
+    get a ``__m{i}`` suffix (e.g. ``x__t3__m0``).
+
+    Naming scheme:
+    - Shared, multi-slot variable: ``"{name}__t{local_index}"``
+    - Shared, single-slot variable: ``"{name}"``
+    - Per-member, multi-slot: ``"{name}__t{local_index}__m{member}"``
+    - Per-member, single-slot: ``"{name}__m{member}"``
+    - Unassigned slot (bug indicator): ``"__unassigned_{global_index}"``
+
+    The local index is the 0-based position within the variable's own slot sequence
+    (i.e. the time step for collocated variables).  Single-slot variables such as
+    integrated states or scalar parameters receive no ``__t`` suffix.
+
+    Square brackets in names are replaced with ``_I`` / ``I_`` because CPLEX does
+    not accept ``[`` or ``]`` in LP variable names.
+
+    Args:
+        indices_per_member: Per-member mapping from variable name to its slot indices
+            in the combined decision vector (as returned by
+            ``_collint_variable_indices_as_lists``).
+        num_total: Total number of slots in the combined decision vector.
+
+    Returns:
+        List of length ``num_total`` mapping each slot index to its LP variable name.
+        Every slot is guaranteed to be filled.
+    """
+    # Single pass over variables: for each variable, determine whether its slots are shared
+    # (identical slot list across all members) or per-member, then write names directly.
+    # Sharing is checked at the slot level using numpy array equality, which correctly
+    # handles the ControlTreeMixin partial-sharing case (same variable name, different
+    # slot lists per member after branching).
+    var_names = [None] * num_total
+    all_names = sorted(set().union(*(d.keys() for d in indices_per_member)))
+    for name in all_names:
+        member_slots = {
+            m: np.array(indices_per_member[m][name], dtype=np.int32)
+            for m in range(len(indices_per_member))
+            if name in indices_per_member[m]
+        }
+
+        # Check if all members that have this variable share the exact same slots.
+        slots_list = list(member_slots.values())
+        shared = len(member_slots) == len(indices_per_member) and all(
+            np.array_equal(slots_list[0], s) for s in slots_list[1:]
+        )
+
+        if shared:
+            slots = slots_list[0]
+            n_slots = len(slots)
+            for local_i, idx in enumerate(slots):
+                var_names[int(idx)] = f"{name}__t{local_i}" if n_slots > 1 else name
+        else:
+            # Per-member or partially shared: warn if different names map to the same slot
+            # (indicates a bug in discretize_controls/discretize_states or a mixin override).
+            for m, slots in member_slots.items():
+                n_slots = len(slots)
+                for local_i, idx in enumerate(slots):
+                    idx = int(idx)
+                    existing = var_names[idx]
+                    if existing is not None and not existing.endswith(f"__m{m}"):
+                        logger.warning(
+                            "Index slot %d maps to different variable names across ensemble "
+                            "members; this indicates a bug in discretize_controls() or "
+                            "discretize_states() (possibly a mixin override). "
+                            "Proceeding with member %d's name (%r); "
+                            "the exported LP file may be incorrect.",
+                            idx,
+                            m,
+                            name,
+                        )
+                    t_part = f"__t{local_i}" if n_slots > 1 else ""
+                    var_names[idx] = f"{name}{t_part}__m{m}"
+
+    for i in range(num_total):
+        if var_names[i] is None:
+            var_names[i] = f"__unassigned_{i}"
+
+    # CPLEX does not like [] in variable names; replace in one vectorized pass
+    arr = np.array(var_names, dtype=str)
+    arr = np.char.replace(arr, "[", "_I")
+    arr = np.char.replace(arr, "]", "I_")
+    return arr.tolist()
+
+
+def _write_lp_file(
+    filename: str,
+    objective_str: str,
+    constraints_str: str,
+    bounds_str: str,
+    binary_vars: list[str],
+    general_vars: list[str],
+    output_folder: str = ".",
+) -> None:
+    """
+    Write the LP file according to the LP format.
+
+    Discrete variables with bounds [0, 1] are written to a ``Binary`` section;
+    other discrete variables (general integers) go to a ``General`` section.
+
+    If a file with the same name already exists, a numeric suffix is appended
+    (e.g. ``problem_1.lp``, ``problem_2.lp``, …).
+
+    Args:
+        filename (str): Base name of the LP file (without directory).
+        objective_str (str): The objective function string.
+        constraints_str (str): The constraints string (empty string if there are no
+            constraints to emit; the ``Subject To`` section is then omitted).
+        bounds_str (str): The bounds string (empty string if no bounds to emit).
+        binary_vars (List[str]): Names of binary (0/1 discrete) variables.
+        general_vars (List[str]): Names of general integer variables.
+        output_folder (str): Directory where the LP file will be written. Defaults to ".".
+
+    Raises:
+        FileNotFoundError: If ``output_folder`` does not exist.
+        PermissionError: If the filesystem denies write access.
+        RuntimeError: If 100 counter-suffixed filenames already exist.
+    """
+
+    stem, ext = os.path.splitext(filename)
+    path = os.path.join(output_folder, filename)
+    counter = 1
+    _MAX_COUNTER = 100
+    while True:
+        try:
+            with open(path, "x") as o:
+                o.write("Minimize\n")
+                o.write(objective_str + "\n")
+                if constraints_str.strip():
+                    o.write("Subject To\n")
+                    o.write(constraints_str + "\n")
+                if bounds_str:
+                    o.write("Bounds\n")
+                    o.write(bounds_str + "\n")
+                if general_vars:
+                    o.write("General\n")
+                    o.write("\n".join(general_vars) + "\n")
+                if binary_vars:
+                    o.write("Binary\n")
+                    o.write("\n".join(binary_vars) + "\n")
+                o.write("End")
+            break
+        except FileExistsError:
+            if counter > _MAX_COUNTER:
+                raise RuntimeError(
+                    f"Could not write LP file: {_MAX_COUNTER} counter-suffixed files already "
+                    f"exist in {output_folder!r} for base name {filename!r}."
+                ) from None
+            path = os.path.join(output_folder, f"{stem}_{counter}{ext}")
+            counter += 1
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"LP export output folder does not exist: {output_folder!r}. "
+                "Create it, or configure a valid output folder for the problem."
+            ) from None

--- a/src/rtctools/optimization/collocated_integrated_optimization_problem.py
+++ b/src/rtctools/optimization/collocated_integrated_optimization_problem.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import time
 import warnings
 from abc import ABCMeta, abstractmethod
 
@@ -14,6 +15,13 @@ from rtctools._internal.casadi_helpers import (
     nullvertcat,
     reduce_matvec,
     substitute_in_external,
+)
+from rtctools._internal.casadi_to_lp import (
+    _build_bounds,
+    _build_constraints,
+    _build_objective,
+    _sanitize_var_names,
+    _write_lp_file,
 )
 from rtctools._internal.debug_check_helpers import DebugLevel, debug_check
 
@@ -834,6 +842,12 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
                         "This will, in general, result in the existence of multiple local optima "
                         "and trouble finding a feasible initial solution."
                     )
+
+            # Store the DAE-derived linearity value so _export_lp_file can check it
+            # independently of transient overrides (e.g. SinglePassGoalProgrammingMixin
+            # sets linear_collocation=False to disable jac_c_constant for IPOPT, which
+            # must not prevent LP export of a problem with a linear DAE).
+            self._dae_linear_collocation = self.linear_collocation
 
             # Transcribe DAE using theta method collocation
             if self.integrate_states:
@@ -2072,6 +2086,84 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
     def solver_input(self):
         return self.__solver_input
 
+    @property
+    def _collint_variable_indices_as_lists(self) -> list[dict]:
+        """Variable name to index mapping (normalized to list[int]) for each ensemble member.
+        Consumed by LP export; avoids re-normalizing the raw int/slice/ndarray values."""
+        return list(self.__indices_as_lists)
+
+    def _export_lp_file(
+        self,
+        f: ca.SX,
+        g: ca.SX,
+        x: ca.SX,
+        lbg: list,
+        ubg: list,
+        lbx: list,
+        ubx: list,
+        discrete: list[bool],
+    ) -> None:
+        """Export the transcribed LP/MILP problem as a file.
+
+        Called by :meth:`optimize` when ``export_lp=True`` is set in :meth:`export_options`.
+        Validates that the problem is compatible with LP/MILP export (affine objective
+        and constraints), builds the LP file representation, and writes it to the output
+        folder. Problems with discrete variables are exported as MILP (with a General
+        section listing integer variables). For ensemble problems, shared variables
+        (controls) are exported without a member suffix; per-member variables (states)
+        receive a ``__m{i}`` suffix (e.g. ``x__t3__m0``).
+
+        Args:
+            f: Symbolic objective expression (already expanded to SX).
+            g: Symbolic constraint expression (already expanded to SX).
+            x: Decision variable vector.
+            lbg, ubg: Lower/upper bounds on constraints.
+            lbx, ubx: Lower/upper bounds on variables.
+            discrete: Boolean array indicating discrete variables.
+
+        Raises:
+            ValueError: If the problem has a non-affine objective or constraints, or
+                uses non-linear collocation (``linear_collocation=False``).
+        """
+        if getattr(self, "_dae_linear_collocation", self.linear_collocation) is False:
+            raise ValueError(
+                "LP/MILP export is not supported for problems with "
+                "non-linear Modelica DAE equations."
+            )
+
+        if not is_affine(f, x):
+            raise ValueError(
+                "LP/MILP export requires the objective function to be affine in the "
+                "decision variables, but the objective is non-linear."
+            )
+
+        if not is_affine(g, x):
+            raise ValueError(
+                "LP/MILP export requires all constraints to be affine in the "
+                "decision variables, but some constraints are non-linear."
+            )
+
+        var_names = _sanitize_var_names(self._collint_variable_indices_as_lists, x.shape[0])
+        obj_str = _build_objective(f, x, var_names)
+        constr_str = _build_constraints(g, x, lbg, ubg, var_names)
+        bounds_str, binary_vars, general_vars = _build_bounds(var_names, lbx, ubx, discrete)
+
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        p = getattr(self, "_gp_current_priority", None)
+        n = getattr(self, "_gp_n_priorities", 0)
+        priority_suffix = f"_priority_{p}" if p is not None and n > 1 else ""
+        filename = f"{self.__class__.__name__}_{timestamp}{priority_suffix}.lp"
+
+        _write_lp_file(
+            filename,
+            obj_str,
+            constr_str,
+            bounds_str,
+            binary_vars,
+            general_vars,
+            output_folder=self._output_folder,
+        )
+
     def solver_options(self):
         options = super().solver_options()
 
@@ -2080,6 +2172,7 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
 
         # Set the option in both cases, to avoid one inadvertently remaining in the cache.
         options[solver]["jac_c_constant"] = "yes" if self.linear_collocation else "no"
+
         return options
 
     def integrator_options(self):

--- a/src/rtctools/optimization/goal_programming_mixin.py
+++ b/src/rtctools/optimization/goal_programming_mixin.py
@@ -691,8 +691,10 @@ class GoalProgrammingMixin(_GoalProgrammingMixinBase):
         self.__results_are_current = False
         self.__original_constant_input_keys = {}
         self.__original_parameter_keys = {}
+        self._gp_n_priorities = len(subproblems)
         for i, (priority, goals, path_goals) in enumerate(subproblems):
             logger.info(f"Solving goals at priority {priority}")
+            self._gp_current_priority = priority
 
             # Call the pre priority hook
             self.priority_started(priority)

--- a/src/rtctools/optimization/goal_programming_mixin_base.py
+++ b/src/rtctools/optimization/goal_programming_mixin_base.py
@@ -512,6 +512,11 @@ class _GoalConstraint:
 
 
 class _GoalProgrammingMixinBase(OptimizationProblem, metaclass=ABCMeta):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._gp_current_priority = None  # Set to the active priority during optimize()
+        self._gp_n_priorities = 0  # Set to the total number of priorities during optimize()
+
     def _gp_n_objectives(self, subproblem_objectives, subproblem_path_objectives, ensemble_member):
         return (
             ca.vertcat(*[o(self, ensemble_member) for o in subproblem_objectives]).size1()

--- a/src/rtctools/optimization/optimization_problem.py
+++ b/src/rtctools/optimization/optimization_problem.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import Any, Literal, overload
 
@@ -95,25 +96,41 @@ class OptimizationProblem(DataStoreAccessor, metaclass=ABCMeta):
         # Create an NLP solver
         logger.debug("Collecting solver options")
 
+        # Set __mixed_integer from the returned discrete array so that solver_options()
+        # selects the correct solver (ipopt vs bonmin) for all transcribe() implementations.
         self.__mixed_integer = np.any(discrete)
         options = {}
         options.update(self.solver_options())  # Create a copy
 
-        logger.debug("Creating solver")
-
-        if options.pop("expand", False):
+        expand = options.pop("expand", False)
+        # export_lp is an output directive read from export_options(); guard against it
+        # being misplaced in solver_options(), where it would leak to the solver. Warn on
+        # the key's presence (any value) and remove it so it never reaches the solver.
+        if "export_lp" in options:
+            del options["export_lp"]
+            warnings.warn(
+                "'export_lp' was set in solver_options(); it is ignored there. "
+                "Set it in export_options() instead. It is an output directive and "
+                "must not be passed to the solver.",
+                UserWarning,
+                stacklevel=2,
+            )
+        # Use .get(): an empty export_options() is a valid "no directives" override.
+        export_lp = self.export_options().get("export_lp", False)
+        if expand or export_lp:
             # NOTE: CasADi only supports the "expand" option for nlpsol. To
             # also be able to expand with e.g. qpsol, we do the expansion
-            # ourselves here.
+            # ourselves here. Expansion is also required for LP export.
             logger.debug("Expanding objective and constraints to SX")
 
-            expand_f_g = ca.Function("f_g", [nlp["x"]], [nlp["f"], nlp["g"]]).expand()
-            X_sx = ca.SX.sym("X", *nlp["x"].shape)
-            f_sx, g_sx = expand_f_g(X_sx)
+            f_sx, g_sx, x_sx = self._expand_nlp(nlp)
 
             nlp["f"] = f_sx
             nlp["g"] = g_sx
-            nlp["x"] = X_sx
+            nlp["x"] = x_sx
+
+            if export_lp:
+                self._export_lp_file(f_sx, g_sx, x_sx, lbg, ubg, lbx, ubx, discrete)
 
         # Debug check for non-linearity in constraints
         self.__debug_check_linearity_constraints(nlp)
@@ -222,6 +239,42 @@ class OptimizationProblem(DataStoreAccessor, metaclass=ABCMeta):
 
         return success
 
+    def _export_lp_file(
+        self,
+        f: ca.SX,
+        g: ca.SX,
+        x: ca.SX,
+        lbg: list,
+        ubg: list,
+        lbx: list,
+        ubx: list,
+        discrete: list[bool],
+    ) -> None:
+        """Export the transcribed LP/MILP problem as a file.
+
+        Called by :meth:`optimize` when ``export_lp`` is requested via :meth:`export_options`.
+        The base implementation raises :exc:`NotImplementedError`; subclasses that support LP
+        export override this method and use :attr:`_collint_variable_indices_as_lists` to map
+        variable names to solver vector indices. See
+        :class:`~rtctools.optimization.collocated_integrated_optimization_problem.CollocatedIntegratedOptimizationProblem`
+        """
+        raise NotImplementedError(
+            "LP/MILP export is only supported for "
+            "CollocatedIntegratedOptimizationProblem subclasses."
+        )
+
+    @staticmethod
+    def _expand_nlp(nlp: dict[str, ca.MX]) -> tuple[ca.SX, ca.SX, ca.SX]:
+        """Expand the MX NLP to SX form and return (f_sx, g_sx, x_sx).
+
+        Used when ``expand=True`` is set in solver options, or when ``export_lp=True``
+        is set in :meth:`export_options`.
+        """
+        expand_f_g = ca.Function("f_g", [nlp["x"]], [nlp["f"], nlp["g"]]).expand()
+        x_sx = ca.SX.sym("x", *nlp["x"].shape)
+        f_sx, g_sx = expand_f_g(x_sx)
+        return f_sx, g_sx, x_sx
+
     def __check_bounds_control_input(self) -> None:
         # Checks if at the control inputs have bounds, log warning when a control input is not
         # bounded.
@@ -268,7 +321,11 @@ class OptimizationProblem(DataStoreAccessor, metaclass=ABCMeta):
         :returns: A dictionary of solver options. See the CasADi and
                   respective solver documentation for details.
         """
-        options = {"error_on_fail": False, "optimized_num_dir": 3, "casadi_solver": ca.nlpsol}
+        options = {
+            "error_on_fail": False,
+            "optimized_num_dir": 3,
+            "casadi_solver": ca.nlpsol,
+        }
 
         if self.__mixed_integer:
             options["solver"] = "bonmin"
@@ -284,6 +341,27 @@ class OptimizationProblem(DataStoreAccessor, metaclass=ABCMeta):
             ipopt_options = options["ipopt"] = {}
             ipopt_options["linear_solver"] = "mumps"
         return options
+
+    def export_options(self) -> dict[str, bool]:
+        """
+        Returns a dictionary of RTC-Tools output directives that control file export.
+
+        Unlike :meth:`solver_options`, these directives are consumed by RTC-Tools
+        itself and are **never** passed to the solver. They are kept separate from
+        the solver options so that code which forwards ``solver_options()`` straight
+        to a CasADi solver (e.g. subproblem solves in downstream mixins) is not
+        affected by export directives.
+
+        Supported directives:
+
+        * ``export_lp`` (:class:`bool`, default ``False``): Export the transcribed
+          problem as an LP/MILP file to the output folder. Only supported for
+          CollocatedIntegratedOptimizationProblem subclasses; see :meth:`_export_lp_file`
+          for the file naming, MILP handling, and the conditions under which it raises.
+
+        :returns: A dictionary of export directives.
+        """
+        return {"export_lp": False}
 
     def solver_success(
         self, solver_stats: dict[str, str | bool], log_solver_failure_as_error: bool

--- a/src/rtctools/optimization/single_pass_goal_programming_mixin.py
+++ b/src/rtctools/optimization/single_pass_goal_programming_mixin.py
@@ -365,6 +365,7 @@ class SinglePassGoalProgrammingMixin(_GoalProgrammingMixinBase):
 
         self.__current_priority = 0
         self.__original_constraints = None
+        self._gp_n_priorities = len(priorities)
 
         self.__objectives_per_priority = []
         self.__path_objectives_per_priority = []
@@ -414,6 +415,7 @@ class SinglePassGoalProgrammingMixin(_GoalProgrammingMixinBase):
 
         for priority in priorities:
             logger.info(f"Solving goals at priority {priority}")
+            self._gp_current_priority = priority
 
             # Call the pre priority hook
             self.priority_started(priority)

--- a/tests/optimization/data/EmptyModel.mo
+++ b/tests/optimization/data/EmptyModel.mo
@@ -1,0 +1,2 @@
+model EmptyModel
+end EmptyModel;

--- a/tests/optimization/data/reference_linear_model.lp
+++ b/tests/optimization/data/reference_linear_model.lp
@@ -1,0 +1,117 @@
+Minimize
+  2 x__t8
+Subject To
+  -1 u__t0 - 1 x__t0 + 8 initial_der(x) = 0
+  -1 x__t0 + 8 initial_der(w) = 0
+  1 x__t0 + 1 y__t0 = 3
+  1 x__t0 = 1.1
+  -1 u__t1 - 8 x__t0 + 7 x__t1 = 0
+  -1 x__t1 - 8 w__t0 + 8 w__t1 = 0
+  1 x__t1 + 1 y__t1 = 3
+  -1 u__t2 - 8 x__t1 + 7 x__t2 = 0
+  -1 x__t2 - 8 w__t1 + 8 w__t2 = 0
+  1 x__t2 + 1 y__t2 = 3
+  -1 u__t3 - 8 x__t2 + 7 x__t3 = 0
+  -1 x__t3 - 8 w__t2 + 8 w__t3 = 0
+  1 x__t3 + 1 y__t3 = 3
+  -1 u__t4 - 8 x__t3 + 7 x__t4 = 0
+  -1 x__t4 - 8 w__t3 + 8 w__t4 = 0
+  1 x__t4 + 1 y__t4 = 3
+  -1 u__t5 - 8 x__t4 + 7 x__t5 = 0
+  -1 x__t5 - 8 w__t4 + 8 w__t5 = 0
+  1 x__t5 + 1 y__t5 = 3
+  -1 u__t6 - 8 x__t5 + 7 x__t6 = 0
+  -1 x__t6 - 8 w__t5 + 8 w__t6 = 0
+  1 x__t6 + 1 y__t6 = 3
+  -1 u__t7 - 8 x__t6 + 7 x__t7 = 0
+  -1 x__t7 - 8 w__t6 + 8 w__t7 = 0
+  1 x__t7 + 1 y__t7 = 3
+  -1 u__t8 - 8 x__t7 + 7 x__t8 = 0
+  -1 x__t8 - 8 w__t7 + 8 w__t8 = 0
+  1 x__t8 + 1 y__t8 = 3
+  -1 x__t0 + 1 _pymoca_delay_0_I1,1I___t0 = 0
+  -0.8 x__t0 - 0.2 x__t1 + 1 _pymoca_delay_0_I1,1I___t1 = 0
+  -0.8 x__t1 - 0.2 x__t2 + 1 _pymoca_delay_0_I1,1I___t2 = 0
+  -0.8 x__t2 - 0.2 x__t3 + 1 _pymoca_delay_0_I1,1I___t3 = 0
+  -0.8 x__t3 - 0.2 x__t4 + 1 _pymoca_delay_0_I1,1I___t4 = 0
+  -0.8 x__t4 - 0.2 x__t5 + 1 _pymoca_delay_0_I1,1I___t5 = 0
+  -0.8 x__t5 - 0.2 x__t6 + 1 _pymoca_delay_0_I1,1I___t6 = 0
+  -0.8 x__t6 - 0.2 x__t7 + 1 _pymoca_delay_0_I1,1I___t7 = 0
+  -0.8 x__t7 - 0.2 x__t8 + 1 _pymoca_delay_0_I1,1I___t8 = 0
+  -1 x__t0 + 1 _pymoca_delay_1_I1,1I___t0 = 0
+  -1 x__t0 + 1 _pymoca_delay_1_I1,1I___t1 = 0
+  -1 x__t1 + 1 _pymoca_delay_1_I1,1I___t2 = 0
+  -1 x__t2 + 1 _pymoca_delay_1_I1,1I___t3 = 0
+  -1 x__t3 + 1 _pymoca_delay_1_I1,1I___t4 = 0
+  -1 x__t4 + 1 _pymoca_delay_1_I1,1I___t5 = 0
+  -1 x__t5 + 1 _pymoca_delay_1_I1,1I___t6 = 0
+  -1 x__t6 + 1 _pymoca_delay_1_I1,1I___t7 = 0
+  -1 x__t7 + 1 _pymoca_delay_1_I1,1I___t8 = 0
+Bounds
+  -2 <= u__t0 <= 2
+  -2 <= u__t1 <= 2
+  -2 <= u__t2 <= 2
+  -2 <= u__t3 <= 2
+  -2 <= u__t4 <= 2
+  -2 <= u__t5 <= 2
+  -2 <= u__t6 <= 2
+  -2 <= u__t7 <= 2
+  -2 <= u__t8 <= 2
+  x__t0 Free
+  x__t1 Free
+  x__t2 Free
+  x__t3 Free
+  x__t4 Free
+  x__t5 Free
+  x__t6 Free
+  x__t7 Free
+  x__t8 Free
+  0 <= w__t0 <= 0
+  w__t1 Free
+  w__t2 Free
+  w__t3 Free
+  w__t4 Free
+  w__t5 Free
+  w__t6 Free
+  w__t7 Free
+  w__t8 Free
+  y__t0 Free
+  y__t1 Free
+  y__t2 Free
+  y__t3 Free
+  y__t4 Free
+  y__t5 Free
+  y__t6 Free
+  y__t7 Free
+  y__t8 Free
+  _pymoca_delay_0_I1,1I___t0 Free
+  _pymoca_delay_0_I1,1I___t1 Free
+  _pymoca_delay_0_I1,1I___t2 Free
+  _pymoca_delay_0_I1,1I___t3 Free
+  _pymoca_delay_0_I1,1I___t4 Free
+  _pymoca_delay_0_I1,1I___t5 Free
+  _pymoca_delay_0_I1,1I___t6 Free
+  _pymoca_delay_0_I1,1I___t7 Free
+  _pymoca_delay_0_I1,1I___t8 Free
+  _pymoca_delay_1_I1,1I___t0 Free
+  _pymoca_delay_1_I1,1I___t1 Free
+  _pymoca_delay_1_I1,1I___t2 Free
+  _pymoca_delay_1_I1,1I___t3 Free
+  _pymoca_delay_1_I1,1I___t4 Free
+  _pymoca_delay_1_I1,1I___t5 Free
+  _pymoca_delay_1_I1,1I___t6 Free
+  _pymoca_delay_1_I1,1I___t7 Free
+  _pymoca_delay_1_I1,1I___t8 Free
+  initial_der(x) Free
+  initial_der(w) Free
+General
+u__t0
+u__t1
+u__t2
+u__t3
+u__t4
+u__t5
+u__t6
+u__t7
+u__t8
+End

--- a/tests/optimization/regenerate_lp_reference.py
+++ b/tests/optimization/regenerate_lp_reference.py
@@ -1,0 +1,38 @@
+"""Regenerate tests/optimization/data/reference_linear_model.lp.
+
+Run this script whenever a change to casadi_to_lp.py or the LinearModel
+intentionally alters the LP output format:
+
+    uv run python -m tests.optimization.regenerate_lp_reference
+
+The script runs LinearModel.optimize() with export_lp=True, captures the
+produced file, and overwrites the reference. Commit the updated reference
+together with the code change.
+"""
+
+import os
+import tempfile
+
+from tests.optimization.test_export_lp import LinearModel
+
+_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+_REFERENCE_PATH = os.path.join(_DATA_DIR, "reference_linear_model.lp")
+
+
+def regenerate():
+    with tempfile.TemporaryDirectory() as output_folder:
+        problem = LinearModel(output_folder=output_folder)
+        problem.optimize()
+        lp_files = [f for f in os.listdir(output_folder) if f.endswith(".lp")]
+        assert len(lp_files) == 1, f"Expected 1 LP file, got {lp_files}"
+        with open(os.path.join(output_folder, lp_files[0])) as f:
+            content = f.read()
+
+    with open(_REFERENCE_PATH, "w", newline="\n") as f:
+        f.write(content)
+
+    print(f"Regenerated {_REFERENCE_PATH} ({len(content.splitlines())} lines)")
+
+
+if __name__ == "__main__":
+    regenerate()

--- a/tests/optimization/test_export_lp.py
+++ b/tests/optimization/test_export_lp.py
@@ -1,0 +1,745 @@
+import contextlib
+import logging
+import os
+import re
+import tempfile
+import unittest
+from unittest import mock
+
+import casadi as ca
+import numpy as np
+from pymoca.backends.casadi.alias_relation import AliasRelation
+
+from rtctools._internal.casadi_to_lp import (
+    LP_FEASIBILITY_EPSILON,
+    _build_bounds,
+    _build_constraints,
+    _build_objective,
+    _sanitize_var_names,
+    _write_lp_file,
+)
+from rtctools.optimization.collocated_integrated_optimization_problem import (
+    CollocatedIntegratedOptimizationProblem,
+)
+from rtctools.optimization.modelica_mixin import ModelicaMixin
+from rtctools.optimization.optimization_problem import OptimizationProblem
+from rtctools.optimization.timeseries import Timeseries
+
+from .data_path import data_path
+
+TERMINAL_STATE_PENALTY = 2.0
+
+# Parameters for floating-point normalization in LP file comparison.
+FP_NOISE_THRESHOLD = 1e-10
+FP_ROUND_DECIMALS = 6
+
+
+@contextlib.contextmanager
+def _suppress_info_logging():
+    """Suppress INFO/DEBUG rtctools output during optimize() calls in tests."""
+    logger = logging.getLogger("rtctools")
+    original_level = logger.level
+    logger.setLevel(logging.WARNING)
+    try:
+        yield
+    finally:
+        logger.setLevel(original_level)
+
+
+def _normalize_lp(text: str) -> str:
+    """Normalize an LP file so that two files representing the same problem compare equal,
+    even when floating-point noise differs across platforms or CasADi versions.
+
+    Steps:
+    1. Round every numeric literal to ``FP_ROUND_DECIMALS`` decimals and
+       collapse values below ``FP_NOISE_THRESHOLD`` to zero.
+    2. Format whole numbers as integers (``10.0`` -> ``10``). Values >= 1e15
+       are kept as floats because float precision (~15 digits) can make
+       non-integers appear whole at that scale.
+    3. Remove zero-coefficient terms (``+ 0 <var>`` / ``- 0 <var>``).
+    4. Collapse whitespace and strip trailing spaces per line.
+    """
+
+    def _round_match(m: re.Match) -> str:
+        """Regex callback: round a single numeric literal."""
+        val = float(m.group(0))
+        if abs(val) < FP_NOISE_THRESHOLD:
+            val = 0.0
+        val = round(val, FP_ROUND_DECIMALS)
+        if val == int(val) and abs(val) < 1e15:
+            return str(int(val))
+        return str(val)
+
+    # Match numeric literals that are NOT part of an identifier.
+    # Negative lookbehind/lookahead on word characters ensures we don't corrupt
+    # variable names that happen to contain digit sequences (e.g. "q1e3", "x10").
+    text = re.sub(r"(?<!\w)-?\d+\.?\d*(?:e[+-]?\d+)?(?!\w)", _round_match, text)
+    text = re.sub(r"[+-]\s*0\s+\S+", "", text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = "\n".join(line.rstrip() for line in text.splitlines())
+    return text.strip() + "\n"
+
+
+# Test models
+
+
+class _BaseTestModel(ModelicaMixin, CollocatedIntegratedOptimizationProblem):
+    """Base test model. Subclasses override class attributes to customize."""
+
+    model_name = "ModelWithInitialLinear"
+    has_parameters = True
+    objective_factory = None
+
+    def __init__(self, output_folder):
+        super().__init__(
+            input_folder=data_path(),
+            output_folder=output_folder,
+            model_name=self.model_name,
+            model_folder=data_path(),
+        )
+
+    def times(self, variable=None):
+        return np.linspace(0.0, 1.0, 9)
+
+    def parameters(self, ensemble_member):
+        parameters = super().parameters(ensemble_member)
+        if self.has_parameters:
+            parameters["u_max"] = 2.0
+        return parameters
+
+    def pre(self):
+        pass
+
+    def constant_inputs(self, ensemble_member):
+        return {"constant_input": Timeseries(self.times(), np.ones(len(self.times())))}
+
+    def seed(self, ensemble_member):
+        return {}
+
+    def objective(self, ensemble_member):
+        xf = self.state_at("x", self.times()[-1], ensemble_member=ensemble_member)
+        if self.objective_factory:
+            return self.objective_factory(xf)
+        return TERMINAL_STATE_PENALTY * xf
+
+    def constraints(self, ensemble_member):
+        return []
+
+    def compiler_options(self):
+        options = super().compiler_options()
+        options["cache"] = False
+        options["library_folders"] = []
+        return options
+
+    def export_options(self):
+        options = super().export_options()
+        options["export_lp"] = True
+        return options
+
+
+class LinearModel(_BaseTestModel):
+    """Linear MILP — LP export should succeed with a General section."""
+
+    def variable_is_discrete(self, variable):
+        return variable == "u"
+
+
+class EnsembleLinearModel(LinearModel):
+    """Linear MILP with two ensemble members — state variables should get __m{i} suffixes."""
+
+    @property
+    def ensemble_size(self):
+        return 2
+
+    def constant_inputs(self, ensemble_member):
+        values = np.ones(len(self.times())) if ensemble_member == 0 else np.zeros(len(self.times()))
+        return {"constant_input": Timeseries(self.times(), values)}
+
+
+class NonLinearModel(_BaseTestModel):
+    """Non-linear DAE — LP export should raise."""
+
+    model_name = "Model"
+    has_parameters = False
+    objective_factory = staticmethod(lambda xf: xf**2)
+
+
+class LinearModelNonAffineObjective(_BaseTestModel):
+    """Linear DAE with non-affine objective — LP export should raise."""
+
+    objective_factory = staticmethod(lambda xf: xf**2)
+
+
+class NonAffineConstraintModel(_BaseTestModel):
+    """Linear DAE with non-affine constraint — LP export should raise."""
+
+    def constraints(self, ensemble_member):
+        xf = self.state_at("x", self.times()[-1], ensemble_member=ensemble_member)
+        return [(xf**2, -np.inf, 1.0)]
+
+
+class _BaseNoModelicaModel(CollocatedIntegratedOptimizationProblem):
+    """Base for models with no DAE equations and a single discrete path variable."""
+
+    def times(self, variable=None):
+        return np.linspace(0.0, 1.0, 5)
+
+    def pre(self):
+        pass
+
+    def seed(self, ensemble_member):
+        return {}
+
+    def export_options(self):
+        options = super().export_options()
+        options["export_lp"] = True
+        return options
+
+    @property
+    def path_variables(self):
+        return super().path_variables + [ca.MX.sym("pump_on")]
+
+    def variable_is_discrete(self, variable):
+        return variable == "pump_on" or super().variable_is_discrete(variable)
+
+    def bounds(self):
+        bounds = super().bounds()
+        bounds["pump_on"] = (0.0, 1.0)
+        return bounds
+
+    def objective(self, ensemble_member):
+        pump_on = self.state_at("pump_on", self.times()[-1], ensemble_member=ensemble_member)
+        return pump_on
+
+    def constraints(self, ensemble_member):
+        return []
+
+    def path_constraints(self, ensemble_member):
+        return []
+
+
+class EmptyModelicaModel(ModelicaMixin, _BaseNoModelicaModel):
+    """Empty Modelica file — linear_collocation is never set by the DAE linearity check."""
+
+    def __init__(self, output_folder):
+        super().__init__(
+            input_folder=data_path(),
+            output_folder=output_folder,
+            model_name="EmptyModel",
+            model_folder=data_path(),
+        )
+
+    def compiler_options(self):
+        options = super().compiler_options()
+        options["cache"] = False
+        options["library_folders"] = []
+        return options
+
+    def variable_is_discrete(self, variable):
+        return variable == "pump_on" or super().variable_is_discrete(variable)
+
+
+class NoModelicaModel(_BaseNoModelicaModel):
+    """No Modelica file — DAE abstract methods implemented as empty stubs."""
+
+    def __init__(self, output_folder):
+        self._dae_variables = {
+            "states": [],
+            "derivatives": [],
+            "algebraics": [],
+            "control_inputs": [],
+            "constant_inputs": [],
+            "lookup_tables": [],
+            "parameters": [],
+            "time": [ca.MX.sym("time")],
+        }
+        self._alias_relation = AliasRelation()
+        super().__init__(input_folder=data_path(), output_folder=output_folder)
+
+    @property
+    def alias_relation(self):
+        return self._alias_relation
+
+    @property
+    def dae_residual(self):
+        return ca.MX()
+
+    @property
+    def dae_variables(self):
+        return self._dae_variables
+
+
+# Unit tests for builder functions
+
+
+class TestLPBuilders(unittest.TestCase):
+    """Unit tests for the pure builder functions in casadi_to_lp."""
+
+    @staticmethod
+    def _make_fg(n_vars, f_expr_fn, g_expr_fn):
+        """Return (f, g, X, var_names) for hand-crafted CasADi expressions."""
+        X = ca.SX.sym("X", n_vars)
+        var_names = [f"x{i}" for i in range(n_vars)]
+        return f_expr_fn(X), g_expr_fn(X), X, var_names
+
+    def test__build_objective(self):
+        """Objective string must include coefficients, constants, and handle edge cases."""
+        # Linear with positive constant — must not start with '+'
+        f, _, X, names = self._make_fg(2, lambda X: 2.0 * X[0] + 10.0, lambda X: X[0])
+        result = _build_objective(f, X, names)
+        self.assertNotRegex(result, r"^\s*\+")
+        self.assertRegex(result, r"2\b")  # coefficient 2 (:.15g strips trailing zeros)
+        self.assertIn("x0", result)
+        self.assertRegex(result, r"\b10\b")
+
+        # Negative constant
+        f, _, X, names = self._make_fg(1, lambda X: 3.0 * X[0] - 5.0, lambda X: X[0])
+        result = _build_objective(f, X, names)
+        self.assertRegex(result, r"3\b.*x0")
+        self.assertRegex(result, r"-\s*5\b")
+
+        # Zero objective must emit explicit '0'
+        f, _, X, names = self._make_fg(1, lambda X: ca.SX(0), lambda X: X[0])
+        result = _build_objective(f, X, names)
+        self.assertEqual(result.strip(), "0")
+
+        # Positive constant-only objective must not emit a leading '+' (invalid LP syntax)
+        f, _, X, names = self._make_fg(1, lambda X: ca.SX(5.0), lambda X: X[0])
+        result = _build_objective(f, X, names)
+        self.assertNotRegex(result, r"^\s*\+")
+        self.assertRegex(result, r"\b5\b")
+
+    def test_build_constraints_operators(self):
+        """Constraint operator and RHS value must match the bound type and magnitude."""
+        # Equal bounds: must emit = not >= or <=
+        _, g, X, names = self._make_fg(1, lambda X: X[0], lambda X: X[0])
+        result = _build_constraints(g, X, [3.0], [3.0], names)
+        self.assertRegex(result.strip(), r"x0\s*=\s*3\b")
+        self.assertNotIn(">=", result)
+        self.assertNotIn("<=", result)
+
+        # Only upper bound finite → <=
+        _, g, X, names = self._make_fg(1, lambda X: X[0], lambda X: X[0])
+        result = _build_constraints(g, X, [-np.inf], [10.0], names)
+        self.assertRegex(result.strip(), r"x0\s*<=\s*10\b")
+
+    def test_build_constraints_range(self):
+        """A constraint with both bounds finite and lb < ub must emit two lines (>= and <=)."""
+        _, g, X, names = self._make_fg(1, lambda X: X[0], lambda X: X[0])
+        result = _build_constraints(g, X, [1.0], [3.0], names)
+        self.assertIn(">=", result)
+        self.assertIn("<=", result)
+        # Both lines must appear with correct RHS (b_i=0 here, so RHS = bound - 0)
+        self.assertRegex(result, r">=\s*1")
+        self.assertRegex(result, r"<=\s*3")
+
+    def test_build_constraints_no_finite_bound_warns_and_emits(self):
+        """A vacuous constraint (no finite bound) must emit a warning and write '<= +Inf'."""
+        _, g, X, names = self._make_fg(1, lambda X: X[0], lambda X: X[0])
+        with self.assertLogs("rtctools", level="WARNING") as log_ctx:
+            result = _build_constraints(g, X, [-np.inf], [np.inf], names)
+        self.assertTrue(
+            any(
+                "vacuous" in msg.lower() or "no finite bound" in msg.lower()
+                for msg in log_ctx.output
+            )
+        )
+        self.assertIn("+Inf", result)
+
+    def test_build_constraints_constant_row_feasible_is_skipped(self):
+        """A constant constraint (no variable terms) within bounds must be omitted.
+
+        Such a row would otherwise be written with an empty LHS (e.g. `` = 0`` / `` <= 0``),
+        which the LP format forbids (every row needs a variable term) and CPLEX rejects.
+        Covers both a zero row (symbolic cancellation) and a non-zero in-bounds constant.
+        """
+        # Row 0: a real constraint; row 1: identically zero via symbolic cancellation.
+        _, g, X, names = self._make_fg(
+            2, lambda X: X[0], lambda X: ca.vertcat(X[0] + X[1], X[0] - X[0])
+        )
+        result = _build_constraints(g, X, [0.0, 0.0], [10.0, 0.0], names)
+
+        real_lines = [ln.strip() for ln in result.splitlines() if ln.strip()]
+        # No line may start with an operator (an empty-LHS row leaking through the skip).
+        for ln in real_lines:
+            self.assertNotIn(ln[0], "=<>", f"empty-LHS constraint line leaked: {ln!r}")
+        # Only the real (range) constraint survives, as its two >= / <= lines.
+        self.assertEqual(len(real_lines), 2)
+        self.assertTrue(all("x0" in ln and "x1" in ln for ln in real_lines))
+
+        # A non-zero constant within bounds (b_i=5 in [0, 10]) is likewise skipped.
+        _, g2, X2, names2 = self._make_fg(1, lambda X: X[0], lambda X: X[0] - X[0] + 5.0)
+        self.assertEqual(_build_constraints(g2, X2, [0.0], [10.0], names2).strip(), "")
+
+    def test_build_constraints_constant_row_both_bounds_infinite_skipped_silently(self):
+        """A constant row with both bounds infinite is vacuous and skipped without warning."""
+        _, g, X, names = self._make_fg(1, lambda X: X[0], lambda X: X[0] - X[0])
+        with self.assertNoLogs("rtctools", level="WARNING"):
+            result = _build_constraints(g, X, [-np.inf], [np.inf], names)
+        self.assertEqual(result.strip(), "")
+
+    def test_build_constraints_constant_row_infeasible_raises(self):
+        """A constant constraint that violates its bounds is infeasible and must raise.
+
+        Covers both the equality-bound violation and a one-sided (upper-only) violation.
+        """
+        # Equality bounds [1, 1] with constant 0 -> violates lower side (row index 1).
+        _, g, X, names = self._make_fg(
+            2, lambda X: X[0], lambda X: ca.vertcat(X[0] + X[1], X[0] - X[0])
+        )
+        with self.assertRaisesRegex(ValueError, r"constraint 1.*lower bound.*infeasible"):
+            _build_constraints(g, X, [0.0, 1.0], [10.0, 1.0], names)
+
+        # One-sided: lb=-inf, ub=5, constant 10 -> violates upper side only (row index 0).
+        _, g2, X2, names2 = self._make_fg(1, lambda X: X[0], lambda X: X[0] - X[0] + 10.0)
+        with self.assertRaisesRegex(ValueError, r"constraint 0.*upper bound.*infeasible"):
+            _build_constraints(g2, X2, [-np.inf], [5.0], names2)
+
+    def test_build_constraints_constant_row_feasibility_tolerance(self):
+        """The feasibility check tolerates noise up to LP_FEASIBILITY_EPSILON, not beyond."""
+        # Just inside the lower bound (within tolerance): feasible -> skipped.
+        _, g, X, names = self._make_fg(
+            1, lambda X: X[0], lambda X: X[0] - X[0] + (1.0 - LP_FEASIBILITY_EPSILON / 2)
+        )
+        self.assertEqual(_build_constraints(g, X, [1.0], [np.inf], names).strip(), "")
+
+        # Clearly below the lower bound (beyond tolerance): infeasible -> raises.
+        _, g2, X2, names2 = self._make_fg(
+            1, lambda X: X[0], lambda X: X[0] - X[0] + (1.0 - 2 * LP_FEASIBILITY_EPSILON)
+        )
+        with self.assertRaisesRegex(ValueError, r"lower bound.*infeasible"):
+            _build_constraints(g2, X2, [1.0], [np.inf], names2)
+
+    def test_build_constraints_all_rows_skipped_returns_empty(self):
+        """If every row is a feasible constant, the result is empty (so the writer omits
+        the ``Subject To`` section rather than emitting a blank line)."""
+        _, g, X, names = self._make_fg(1, lambda X: X[0], lambda X: X[0] - X[0])
+        self.assertEqual(_build_constraints(g, X, [0.0], [10.0], names), "")
+
+    def test__sanitize_var_names(self):
+        """_sanitize_var_names must assign __m{i} suffixes to per-member variables and omit
+        them for shared variables. Sharing is determined at variable level: if any member has
+        a different slot list, all slots of that variable get member suffixes."""
+        cases = [
+            (
+                "ensemble_shared_control",
+                # u is shared (same slots in all members); x is per-member
+                [{"u": [0, 1], "x": [2, 3]}, {"u": [0, 1], "x": [4, 5]}],
+                6,
+                {
+                    0: "u__t0",
+                    1: "u__t1",
+                    2: "x__t0__m0",
+                    3: "x__t1__m0",
+                    4: "x__t0__m1",
+                    5: "x__t1__m1",
+                },
+            ),
+            (
+                "partial_sharing_all_per_member",
+                # u has non-overlapping slot lists per member → all per-member
+                [{"u": [0, 1]}, {"u": [2, 3]}, {"u": [4, 5]}],
+                6,
+                {
+                    0: "u__t0__m0",
+                    1: "u__t1__m0",
+                    2: "u__t0__m1",
+                    3: "u__t1__m1",
+                    4: "u__t0__m2",
+                    5: "u__t1__m2",
+                },
+            ),
+            (
+                "scalar_shared_no_t_suffix",
+                # p occupies 1 slot (scalar, shared): name has no __t suffix
+                [{"p": [0], "x": [1, 2]}, {"p": [0], "x": [3, 4]}],
+                5,
+                {0: "p", 1: "x__t0__m0", 2: "x__t1__m0", 3: "x__t0__m1", 4: "x__t1__m1"},
+            ),
+            (
+                "interleaved_slots_control_tree",
+                # Non-contiguous slots (ControlTreeMixin layout): u shared at [0,2], x per-member
+                [{"u": [0, 2], "x": [1, 3]}, {"u": [0, 2], "x": [4, 5]}],
+                6,
+                {
+                    0: "u__t0",
+                    2: "u__t1",
+                    1: "x__t0__m0",
+                    3: "x__t1__m0",
+                    4: "x__t0__m1",
+                    5: "x__t1__m1",
+                },
+            ),
+        ]
+        for case_name, indices, n_vars, expected in cases:
+            with self.subTest(case=case_name):
+                names = _sanitize_var_names(indices, n_vars)
+                for slot, expected_name in expected.items():
+                    self.assertEqual(
+                        names[slot], expected_name, msg=f"case={case_name}, slot={slot}"
+                    )
+
+    def test_write_lp_file_no_overwrite(self):
+        """_write_lp_file() must not overwrite an existing file; it appends a counter instead."""
+        var_names = ["x__0"]
+        discrete = [False]
+        lbx = [0.0]
+        ubx = [1.0]
+        bounds_str, binary_vars, general_vars = _build_bounds(var_names, lbx, ubx, discrete)
+        with tempfile.TemporaryDirectory() as output_folder:
+            for _ in range(2):
+                _write_lp_file(
+                    "test.lp",
+                    "0",
+                    "  0 = 0",
+                    bounds_str,
+                    binary_vars,
+                    general_vars,
+                    output_folder,
+                )
+            files = {f for f in os.listdir(output_folder) if f.endswith(".lp")}
+            self.assertEqual(files, {"test.lp", "test_1.lp"})
+
+    def test_write_lp_file_binary_and_general(self):
+        """Binary variables (bounds [0,1]) go to Binary section; others go to General."""
+        var_names = ["x__0", "y__1", "z__2"]
+        discrete = [True, True, False]
+        lbx = [0, -5, 0]
+        ubx = [1, 10, 100]
+        bounds_str, binary_vars, general_vars = _build_bounds(var_names, lbx, ubx, discrete)
+        with tempfile.TemporaryDirectory() as output_folder:
+            _write_lp_file(
+                "test.lp", "0", "  0 = 0", bounds_str, binary_vars, general_vars, output_folder
+            )
+            with open(os.path.join(output_folder, "test.lp")) as f:
+                content = f.read()
+
+        self.assertIn("Binary", content)
+        binary_section = content.split("Binary")[1].split("End")[0]
+        self.assertIn("x__0", binary_section)
+        self.assertNotIn("y__1", binary_section)
+        self.assertNotIn("z__2", binary_section)
+
+        self.assertIn("General", content)
+        general_section = content.split("General")[1].split("Binary")[0]
+        self.assertIn("y__1", general_section)
+        self.assertNotIn("x__0", general_section)
+        self.assertNotIn("z__2", general_section)
+
+    def test_write_lp_file_no_bounds_section_for_pure_binary(self):
+        """_write_lp_file must omit the Bounds section entirely when bounds_str is empty."""
+        with tempfile.TemporaryDirectory() as output_folder:
+            _write_lp_file("test.lp", "0", "  0 = 0", "", ["b__0"], [], output_folder)
+            with open(os.path.join(output_folder, "test.lp")) as f:
+                content = f.read()
+        self.assertNotIn("Bounds", content)
+        self.assertIn("Binary", content)
+
+    def test_write_lp_file_no_subject_to_section_when_no_constraints(self):
+        """_write_lp_file must omit the Subject To section when constraints_str is empty
+        (or whitespace), to avoid emitting a blank constraint line some readers reject."""
+        with tempfile.TemporaryDirectory() as output_folder:
+            _write_lp_file("test.lp", "0", "", "0 <= x__0 <= 1", [], [], output_folder)
+            with open(os.path.join(output_folder, "test.lp")) as f:
+                content = f.read()
+        self.assertNotIn("Subject To", content)
+        self.assertIn("Bounds", content)
+
+    def test_build_bounds_returns_tuple_with_classified_vars(self):
+        """_build_bounds must return (bounds_str, binary_vars, general_vars)."""
+        var_names = ["b__0", "g__1", "c__2"]
+        discrete = [True, True, False]
+        lbx = [0.0, -5.0, 0.0]
+        ubx = [1.0, 10.0, 100.0]
+        bounds_str, binary_vars, general_vars = _build_bounds(var_names, lbx, ubx, discrete)
+
+        self.assertIn("b__0", binary_vars)
+        self.assertNotIn("b__0", bounds_str)
+
+        self.assertIn("g__1", general_vars)
+        self.assertIn("g__1", bounds_str)
+
+        self.assertNotIn("c__2", binary_vars)
+        self.assertNotIn("c__2", general_vars)
+        self.assertIn("c__2", bounds_str)
+
+        bounds_str_free, _, _ = _build_bounds(["f__0"], [-np.inf], [np.inf], [False])
+        self.assertIn("Free", bounds_str_free)
+
+    def test_write_lp_file_missing_output_folder(self):
+        """_write_lp_file raises FileNotFoundError when folder does not exist."""
+        var_names = ["x__0"]
+        bounds_str, binary_vars, general_vars = _build_bounds(var_names, [0], [1], [False])
+        with self.assertRaises(FileNotFoundError) as ctx:
+            _write_lp_file(
+                "test.lp",
+                "0",
+                "  0 = 0",
+                bounds_str,
+                binary_vars,
+                general_vars,
+                output_folder="/nonexistent/folder/that/does/not/exist",
+            )
+        self.assertIn("output folder", str(ctx.exception).lower())
+        self.assertIn("/nonexistent/folder/that/does/not/exist", str(ctx.exception))
+
+    def test_export_lp_raises_not_implemented_for_non_collocated(self):
+        """OptimizationProblem._export_lp_file must raise NotImplementedError.
+
+        Only CollocatedIntegratedOptimizationProblem implements LP export; calling the
+        base-class method directly must raise with a clear message naming the required class.
+        """
+        mock_problem = mock.Mock(spec=["_output_folder"])
+        x = ca.SX.sym("x", 1)
+        with self.assertRaises(NotImplementedError) as ctx:
+            OptimizationProblem._export_lp_file(mock_problem, x, x, x, [0], [0], [0], [0], [False])
+        self.assertIn("CollocatedIntegratedOptimizationProblem", str(ctx.exception))
+
+
+# Functional export tests
+
+
+class TestExportLP(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Run the linear MILP model once and share results across all tests."""
+        with _suppress_info_logging(), tempfile.TemporaryDirectory() as output_folder:
+            problem = LinearModel(output_folder=output_folder)
+            problem.optimize()
+            cls._lp_files = [f for f in os.listdir(output_folder) if f.endswith(".lp")]
+            with open(os.path.join(output_folder, cls._lp_files[0])) as f:
+                cls._lp_content = f.read()
+
+    def test_lp_export_success(self):
+        """Successful export must produce one correctly named file matching the reference."""
+        # File naming and location
+        self.assertEqual(len(self._lp_files), 1)
+        self.assertTrue(self._lp_files[0].startswith("LinearModel_"))
+        self.assertFalse(os.path.exists(os.path.join(os.getcwd(), self._lp_files[0])))
+
+        # MILP: General section must list the discrete variable but not continuous ones
+        self.assertIn("General", self._lp_content)
+        general_section = self._lp_content.split("General")[1].split("End")[0]
+        self.assertIn("u__", general_section)
+        self.assertNotIn("x__", general_section)
+        self.assertNotIn("w__", general_section)
+
+        # Scalar variables (1 slot) must appear without __t suffix
+        self.assertIn("initial_der(x)", self._lp_content)
+        self.assertNotIn("initial_der(x)__t", self._lp_content)
+        self.assertIn("initial_der(w)", self._lp_content)
+        self.assertNotIn("initial_der(w)__t", self._lp_content)
+
+        # Content must match reference after FP normalization
+        reference_path = os.path.join(data_path(), "reference_linear_model.lp")
+        with open(reference_path) as f:
+            reference = _normalize_lp(f.read())
+
+        self.assertEqual(
+            _normalize_lp(self._lp_content),
+            reference,
+            f"Normalized LP output does not match {reference_path}. "
+            "If the change is intentional, regenerate the reference file:\n"
+            "  If using uv:      uv run python -m tests.optimization.regenerate_lp_reference\n"
+            "  Otherwise use:    python -m tests.optimization.regenerate_lp_reference",
+        )
+
+    def test_lp_export_ensemble(self):
+        """Ensemble export: one LP file, states suffixed __m{i}, controls unsuffixed."""
+        with _suppress_info_logging(), tempfile.TemporaryDirectory() as output_folder:
+            problem = EnsembleLinearModel(output_folder=output_folder)
+            problem.optimize()
+            lp_files = [f for f in os.listdir(output_folder) if f.endswith(".lp")]
+            self.assertEqual(len(lp_files), 1)
+            with open(os.path.join(output_folder, lp_files[0])) as f:
+                content = f.read()
+
+        # Controls are shared — no member suffix
+        self.assertIn("u__t0", content)
+        self.assertNotIn("u__t0__m0", content)
+
+        # States are per-member — both suffixes must appear in the Bounds section
+        bounds_section = content.split("Bounds")[1].split("End")[0]
+        self.assertRegex(bounds_section, r"x__t\d+__m0")
+        self.assertRegex(bounds_section, r"x__t\d+__m1")
+
+    def test_lp_export_rejects_invalid_problems(self):
+        """Export must raise ValueError for non-affine or unsupported problems.
+
+        Each case runs its own optimization (not shared via setUpClass) because
+        the error is expected to occur during optimize(), not after.
+        """
+        self._assert_raises_on_optimize(NonLinearModel, "modelica", "dae")
+        self._assert_raises_on_optimize(LinearModelNonAffineObjective, "affine", "objective")
+        self._assert_raises_on_optimize(NonAffineConstraintModel, "affine", "constraint")
+
+    def test_lp_export_no_dae_equations(self):
+        """LP export must succeed when there are no DAE equations
+        (linear_collocation stays None)."""
+        for model_class in (EmptyModelicaModel, NoModelicaModel):
+            with _suppress_info_logging(), tempfile.TemporaryDirectory() as output_folder:
+                problem = model_class(output_folder=output_folder)
+                problem.optimize()
+                lp_files = [f for f in os.listdir(output_folder) if f.endswith(".lp")]
+                self.assertEqual(len(lp_files), 1, f"{model_class.__name__} produced no LP file")
+                with open(os.path.join(output_folder, lp_files[0])) as f:
+                    content = f.read()
+                self.assertIn(
+                    "Binary",
+                    content,
+                    f"{model_class.__name__}: pump_on should be in Binary section",
+                )
+                binary_section = content.split("Binary")[1].split("End")[0]
+                self.assertIn("pump_on__", binary_section)
+                self.assertNotIn(
+                    "General",
+                    content,
+                    f"{model_class.__name__}: no integer variables, General section must be absent",
+                )
+
+    def test_export_lp_not_in_solver_options(self):
+        """``export_lp`` must live in export_options(), never in solver_options().
+
+        Keeping it out of solver_options() means direct consumers of that dict (e.g.
+        ``PumpingStationMixin.__solve_hq_subproblem``) need not know about or defensively
+        strip ``export_lp`` to avoid CasADi rejecting it as an unknown option.
+        """
+        # Base default: export disabled, and the directive is in export_options().
+        self.assertEqual(OptimizationProblem.export_options(mock.Mock()), {"export_lp": False})
+
+        # The directive must never appear in the solver options dict.
+        with tempfile.TemporaryDirectory() as output_folder:
+            problem = LinearModel(output_folder=output_folder)
+            self.assertNotIn("export_lp", problem.solver_options())
+
+    def test_export_lp_in_solver_options_warns(self):
+        """export_lp set in solver_options() (a natural mistake) must warn."""
+
+        class MisplacedExportLP(LinearModel):
+            def solver_options(self):
+                options = super().solver_options()
+                options["export_lp"] = True  # wrong place on purpose
+                return options
+
+            def export_options(self):
+                # Disable actual LP export; this test only checks the misplacement warning.
+                return {"export_lp": False}
+
+        with _suppress_info_logging(), tempfile.TemporaryDirectory() as output_folder:
+            problem = MisplacedExportLP(output_folder=output_folder)
+            with self.assertWarnsRegex(UserWarning, "export_options"):
+                problem.optimize()
+
+    def _assert_raises_on_optimize(self, model_class, *expected_words):
+        """Run optimize() on model_class and assert it raises ValueError with expected_words."""
+        with tempfile.TemporaryDirectory() as output_folder:
+            problem = model_class(output_folder=output_folder)
+            with self.assertRaises(ValueError) as ctx:
+                problem.optimize()
+
+            error_msg = str(ctx.exception).lower()
+            for word in expected_words:
+                self.assertIn(word, error_msg)
+
+            lp_files = [f for f in os.listdir(output_folder) if f.endswith(".lp")]
+            self.assertEqual(len(lp_files), 0)


### PR DESCRIPTION
Adds an `export_lp` directive that exports the transcribed optimization problem as a standard-format LP/MILP file — useful for debugging, inspecting what the solver actually receives, or handing the problem to an external solver (CPLEX, Gurobi, HiGHS).

When enabled, the problem is validated for affinity, expanded to SX, and written to the output folder. Files are named `{ClassName}_{datetime}.lp`, with an optional `_priority_{n}` suffix for goal-programming problems with multiple priorities. An existing file of the same name is preserved by appending a numeric counter.

### Usage

`export_lp` is set via the new `export_options()` method, **not** `solver_options()`:

```python
def export_options(self):
    options = super().export_options()
    options["export_lp"] = True
    return options
```

Only supported for `CollocatedIntegratedOptimizationProblem` subclasses with affine objectives and constraints; raises `ValueError` otherwise.

### Why a separate `export_options()` method

`export_lp` is an output directive, not a solver option — it does not affect solving. Keeping it out of `solver_options()` ensures it is never forwarded to the solver. Code that builds a CasADi solver directly from `solver_options()` (e.g. `PumpingStationMixin.__solve_hq_subproblem` in `rtc-tools-hydraulic-structures`) would otherwise receive the unknown `export_lp` key and fail, since CasADi rejects unknown options. `optimize()` additionally warns and strips `export_lp` if it is mistakenly placed in `solver_options()`.

### Changes

- New module `_internal/casadi_to_lp.py` with LP-format builder functions (`_build_objective`, `_build_constraints`, `_build_bounds`, `_sanitize_var_names`, `_write_lp_file`). `LP_COEFF_EPSILON` suppresses noise from CasADi's symbolic differentiation; coefficients are extracted via `ca.linear_coeff()`.
- New `export_options()` method on `OptimizationProblem` as a dedicated channel for output directives; read by `optimize()` and never passed to the solver.
- New `_export_lp_file()` method on `CollocatedIntegratedOptimizationProblem`, with `_collint_variable_indices_as_lists` for readable variable names.
- MILP support — discrete variables emit a `Binary` section (bounds `[0, 1]`) or `General` section (other integers).
- Priority-aware filenames for goal programming (distinct file per priority when there are multiple).
- Constant constraint rows (no variable terms) are handled rather than emitted as `0 = 0` / `0 <= 0`, which the LP format forbids and CPLEX rejects: feasible rows are skipped; infeasible ones raise `ValueError` naming the violated constraint.
- Tests — `TestLPBuilders` (unit tests for the pure builders) and `TestExportLP` (functional tests on a real Modelica model, MILP export, reference-file comparison, and the `solver_options()`-misplacement warning).

Validated end-to-end by running the pumped-hydropower-system example with `export_lp=True` and solving the exported LP from the last priority with HiGHS.

A follow-up PR (#1785) extends this with named constraint rows and preserves infeasible constant rows via a dummy variable instead of raising.

Resolves #1776
