### PR TITLE
Fix (optimization): Raise ValueError for non-symbolic scalar constraints

### DIFF
--- a/src/rtctools/optimization/collocated_integrated_optimization_problem.py
+++ b/src/rtctools/optimization/collocated_integrated_optimization_problem.py
@@ -1932,6 +1932,13 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
                 for i, (g_i, lbg_i, ubg_i) in enumerate(
                     zip(g_constraint, lbg_constraint, ubg_constraint, strict=True)
                 ):
+                    if isinstance(g_i, (int, float, np.generic)):
+                        raise ValueError(
+                            f"Constraint #{i} expression is a plain Python or NumPy scalar "
+                            f"({type(g_i).__name__}). Constraint expressions must be CasADi "
+                            f"symbolic expressions. If this resulted from a symbolic "
+                            f"simplification, wrap it explicitly using ca.MX(value)."
+                        )
                     s = g_i.size1()
                     if s > 1:
                         if not isinstance(lbg_i, np.ndarray) or lbg_i.shape[0] == 1:

--- a/tests/optimization/test_vector_constraints_variables.py
+++ b/tests/optimization/test_vector_constraints_variables.py
@@ -775,6 +775,26 @@ class InvalidVectorConstraintUbg(ModelAdditionalVariablesVector):
         return constraints
 
 
+class ModelScalarConstraints(Model):
+    def constraints(self, ensemble_member):
+        return [(1.0, 1.0, 1.0)]
+
+
+class ModelNumpyScalarConstraints(Model):
+    def constraints(self, ensemble_member):
+        return [(np.float64(0.5), 0.0, 1.0)]
+
+
+class TestScalarConstraints(TestCase):
+    def test_python_scalar_constraint_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            ModelScalarConstraints().transcribe()
+
+    def test_numpy_scalar_constraint_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            ModelNumpyScalarConstraints().transcribe()
+
+
 class TestInvalidVectorConstraints(TestCase):
     def test_vector_constraint_lbg(self):
         self.problem = InvalidVectorConstraintLbg()


### PR DESCRIPTION
Previously, passing a plain Python float or NumPy scalar as a constraint expression raised a cryptic AttributeError on `.size1()`.

This PR replaces that with a clear ValueError that explains the issue and guides the user toward the correct fix.

 Two cases are distinguished:
  - User error: plain float or numpy scalar passed directly as a constraint expression → ValueError with actionable message
  - Valid: CasADi symbolic expression simplified to a scalar (e.g. x - x → MX(0)) → still has `size1()`, accepted as before
 
Added regression test in `test_vector_constraints_variables.py`.
   