### PR TITLE
feat(util): add RTCTOOLS_EXTRA_CASADIPATH for custom solver plugin path

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -77,7 +77,6 @@ lexicographic goal programming methods, as well as optimization under
 uncertainty using ensemble forecasts.
 
 
-
 Contents
 ========
 

--- a/doc/optimization.rst
+++ b/doc/optimization.rst
@@ -17,3 +17,4 @@ Contents:
    optimization/initial_state_estimation
    optimization/multi_objective
    optimization/forecast_uncertainty
+   optimization/solver_configuration

--- a/doc/optimization/solver_configuration.rst
+++ b/doc/optimization/solver_configuration.rst
@@ -1,0 +1,32 @@
+Solver Configuration
+====================
+
+CasADi searches for solver plugins (e.g. HiGHS, IPOPT) in the directories listed in
+``CASADIPATH``, but only after its own installation directory. This means it is not
+possible to override a bundled solver using ``CASADIPATH`` alone.
+
+To prepend a custom directory to CasADi's plugin search path, set the
+``RTCTOOLS_EXTRA_CASADIPATH`` environment variable:
+
+.. code-block:: bash
+
+   # Linux/macOS
+   export RTCTOOLS_EXTRA_CASADIPATH="/path/to/custom/solver/lib"
+
+   # Windows
+   set RTCTOOLS_EXTRA_CASADIPATH=C:\path\to\custom\solver\lib
+
+This is equivalent to ``CASADIPATH``, but with higher priority. The directory is
+prepended to CasADi's search path by ``run_optimization_problem()`` and
+``run_simulation_problem()`` before the solver is instantiated.
+
+The directory must contain a **CasADi plugin wrapper** for the solver (e.g.
+``libcasadi_conic_highs.so`` on Linux or ``libcasadi_conic_highs.dll`` on Windows).
+This is the shared library that CasADi loads to interface with the solver — placing
+only the raw solver library (e.g. ``libhighs.so``) in the directory is not sufficient.
+
+To use a different solver version than the one bundled with CasADi, place the new solver
+library alongside a compatible plugin wrapper in the directory. If the new solver version
+is ABI-compatible with the bundled one, the existing wrapper may work as-is. Otherwise,
+you need to build a new plugin wrapper using the same toolchain as your CasADi
+installation, linked against the new solver version.

--- a/doc/optimization/solver_configuration.rst
+++ b/doc/optimization/solver_configuration.rst
@@ -1,0 +1,70 @@
+Using a custom solver version
+=============================
+
+Setting the solver path
+-----------------------
+
+CasADi searches its own installation directory before ``CASADIPATH``, so
+``CASADIPATH`` alone cannot reliably override a bundled solver. ``RTCTOOLS_EXTRA_CASADIPATH``
+is used instead — it is prepended to CasADi's search path before the solver is
+instantiated, giving it the highest priority.
+
+``RTCTOOLS_EXTRA_CASADIPATH`` is read by :func:`.run_optimization_problem` and
+:func:`.run_simulation_problem`. If you instantiate a problem class directly, configure
+the path yourself before solving using ``casadi.GlobalOptions.getCasadiPath()`` and
+``casadi.GlobalOptions.setCasadiPath()`` — read the current path first and prepend to it,
+rather than replacing it outright, to preserve the CasADi install directory.
+
+When the path is set, RTC-Tools logs the active CasADi plugin search path at ``INFO``
+level so you can confirm the override is in effect.
+
+.. code-block:: bash
+
+   # Linux/macOS
+   export RTCTOOLS_EXTRA_CASADIPATH="/path/to/custom/solver/lib"
+
+   # Windows
+   set RTCTOOLS_EXTRA_CASADIPATH=C:\path\to\custom\solver\lib
+
+**Windows only:** the solver library (e.g. ``libhighs.dll``) is a transitive dependency
+of the plugin wrapper and is resolved by the standard Windows DLL search order (``PATH``).
+Set ``PATH`` to include the custom solver directory **before starting the Python process**
+so that the correct version is found rather than any copy already present on the system:
+
+.. code-block:: bat
+
+   set PATH=C:\path\to\custom\solver\lib;%PATH%
+   set RTCTOOLS_EXTRA_CASADIPATH=C:\path\to\custom\solver\lib
+
+Custom solver folder contents
+-----------------------------
+
+The directory must contain the solver library and the CasADi plugin wrapper.
+For HiGHS as an example:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Linux
+     - Windows
+     - Role
+   * - ``libhighs.so``
+     - ``libhighs.dll``
+     - Solver library
+   * - ``libcasadi_conic_highs.so``
+     - ``libcasadi_conic_highs.dll``
+     - CasADi plugin wrapper
+
+The plugin wrapper is compiled against both the CasADi source (for internal headers)
+and the HiGHS headers. The solver library must match the HiGHS version the wrapper was
+compiled against — the headers encode vtable layouts and struct sizes that must match
+exactly. Using mismatched versions causes silent data corruption or crashes at runtime.
+The bundled CasADi wrapper cannot be reused for a different HiGHS version — always
+build a new one.
+
+.. note::
+
+   If the plugin directory exists but the wrapper fails to load (e.g. ABI mismatch or a
+   missing transitive DLL on Windows), CasADi reports the error when the solver is
+   instantiated, not when the path is configured. Check the CasADi error output in that
+   case.

--- a/src/rtctools/util.py
+++ b/src/rtctools/util.py
@@ -26,6 +26,30 @@ def _resolve_folder(kwargs, base_folder, subfolder_kw, default):
         return os.path.join(base_folder, subfolder)
 
 
+def _configure_extra_casadi_path(logger):
+    """Prepend RTCTOOLS_EXTRA_CASADIPATH to CasADi's plugin search path."""
+    if extra_casadi_path := os.getenv("RTCTOOLS_EXTRA_CASADIPATH", "").strip():
+        current_parts = [
+            p for p in (casadi.GlobalOptions.getCasadiPath() or "").split(os.pathsep) if p
+        ]
+        current_set = {os.path.normpath(p) for p in current_parts}
+        seen = set()
+        new_parts = []
+        for p in extra_casadi_path.split(os.pathsep):
+            if p and (norm := os.path.normpath(p)) not in current_set and norm not in seen:
+                new_parts.append(p)
+                seen.add(norm)
+        for p in new_parts:
+            if not os.path.isdir(p):
+                logger.warning(
+                    "RTCTOOLS_EXTRA_CASADIPATH entry %r does not exist or is not a directory.", p
+                )
+        if new_parts:
+            combined = os.pathsep.join(new_parts + current_parts)
+            logger.debug("Setting CasADi plugin search path to '%s'.", combined)
+            casadi.GlobalOptions.setCasadiPath(combined)
+
+
 def run_optimization_problem(
     optimization_problem_class, base_folder="..", log_level=logging.INFO, profile=False, **kwargs
 ):
@@ -99,6 +123,8 @@ def run_optimization_problem(
     # Log version info
     logger.info(f"Using RTC-Tools {__version__}.")
     logger.debug(f"Using CasADi {casadi.__version__}.")
+
+    _configure_extra_casadi_path(logger)
 
     # Check for some common mistakes in inheritance order
     suggested_order = OrderedSet(
@@ -231,6 +257,8 @@ def run_simulation_problem(
 
     logger.info(f"Using RTC-Tools {__version__}")
     logger.debug(f"Using CasADi {casadi.__version__}.")
+
+    _configure_extra_casadi_path(logger)
 
     # Run
     prob = simulation_problem_class(

--- a/src/rtctools/util.py
+++ b/src/rtctools/util.py
@@ -26,6 +26,29 @@ def _resolve_folder(kwargs, base_folder, subfolder_kw, default):
         return os.path.join(base_folder, subfolder)
 
 
+def _configure_extra_casadi_path(logger):
+    """Prepend RTCTOOLS_EXTRA_CASADIPATH to CasADi's plugin search path."""
+    if extra_casadi_path := os.getenv("RTCTOOLS_EXTRA_CASADIPATH", "").strip():
+        current_path = casadi.GlobalOptions.getCasadiPath()
+        current_parts = current_path.split(os.pathsep) if current_path else []
+        seen = {os.path.normcase(os.path.normpath(p)) for p in current_parts}
+        new_parts = []
+        for p in extra_casadi_path.split(os.pathsep):
+            norm = os.path.normcase(os.path.normpath(p))
+            if norm not in seen:
+                seen.add(norm)
+                new_parts.append(p)
+                if not os.path.isdir(norm):
+                    logger.warning(
+                        f"RTCTOOLS_EXTRA_CASADIPATH entry {p!r} does not exist"
+                        " or is not a directory."
+                    )
+        if new_parts:
+            combined = os.pathsep.join(new_parts + current_parts)
+            logger.info(f"Setting CasADi plugin search path to '{combined}'.")
+            casadi.GlobalOptions.setCasadiPath(combined)
+
+
 def run_optimization_problem(
     optimization_problem_class, base_folder="..", log_level=logging.INFO, profile=False, **kwargs
 ):
@@ -99,6 +122,8 @@ def run_optimization_problem(
     # Log version info
     logger.info(f"Using RTC-Tools {__version__}.")
     logger.debug(f"Using CasADi {casadi.__version__}.")
+
+    _configure_extra_casadi_path(logger)
 
     # Check for some common mistakes in inheritance order
     suggested_order = OrderedSet(
@@ -231,6 +256,8 @@ def run_simulation_problem(
 
     logger.info(f"Using RTC-Tools {__version__}")
     logger.debug(f"Using CasADi {casadi.__version__}.")
+
+    _configure_extra_casadi_path(logger)
 
     # Run
     prob = simulation_problem_class(

--- a/tests/optimization/test_extra_casadipath.py
+++ b/tests/optimization/test_extra_casadipath.py
@@ -1,0 +1,125 @@
+import logging
+import os
+from unittest.mock import patch
+
+from rtctools.util import _configure_extra_casadi_path
+
+from ..test_case import TestCase
+
+logger = logging.getLogger("rtctools")
+
+
+class TestExtraCasadiPath(TestCase):
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": "/custom/path"})
+    @patch("rtctools.util.casadi")
+    def test_prepends_to_existing_path(self, mock_casadi):
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = "/casadi/default"
+
+        with self.assertLogs("rtctools", level=logging.DEBUG) as cm:
+            _configure_extra_casadi_path(logger)
+
+        call_args = mock_casadi.GlobalOptions.setCasadiPath.call_args.args[0]
+        self.assertEqual(call_args.split(os.pathsep), ["/custom/path", "/casadi/default"])
+        # The DEBUG log must mention the resulting combined path.
+        # assertLogs output format is "LEVEL:logger:message".
+        self.assertTrue(
+            any(call_args in r and r.startswith("DEBUG:") for r in cm.output),
+            f"Expected combined path in DEBUG log output, got: {cm.output}",
+        )
+
+    @patch("rtctools.util.casadi")
+    def test_absent_env_var_does_nothing(self, mock_casadi):
+        os.environ.pop("RTCTOOLS_EXTRA_CASADIPATH", None)
+        with self.assertNoLogs("rtctools", level=logging.DEBUG):
+            _configure_extra_casadi_path(logger)
+        mock_casadi.GlobalOptions.getCasadiPath.assert_not_called()
+        mock_casadi.GlobalOptions.setCasadiPath.assert_not_called()
+
+    @patch("rtctools.util.casadi")
+    def test_empty_or_whitespace_env_var_does_nothing(self, mock_casadi):
+        """Empty and whitespace-only values must both be treated as absent."""
+        for value in ("", " "):
+            mock_casadi.reset_mock()
+            with patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": value}):
+                with self.assertNoLogs("rtctools", level=logging.DEBUG):
+                    _configure_extra_casadi_path(logger)
+            mock_casadi.GlobalOptions.getCasadiPath.assert_not_called()
+            mock_casadi.GlobalOptions.setCasadiPath.assert_not_called()
+
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": "/custom/path"})
+    @patch("rtctools.util.casadi")
+    def test_no_separator_artefacts_when_existing_path_absent(self, mock_casadi):
+        """getCasadiPath() returning None or "" must not introduce separator artefacts."""
+        for return_value in (None, ""):
+            mock_casadi.reset_mock()
+            mock_casadi.GlobalOptions.getCasadiPath.return_value = return_value
+
+            with self.assertLogs("rtctools", level=logging.DEBUG):
+                _configure_extra_casadi_path(logger)
+
+            call_args = mock_casadi.GlobalOptions.setCasadiPath.call_args.args[0]
+            self.assertEqual(
+                call_args, "/custom/path", f"Failed for getCasadiPath()={return_value!r}"
+            )
+
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": "/custom/path"})
+    @patch("rtctools.util.casadi")
+    def test_already_in_existing_path_is_not_prepended(self, mock_casadi):
+        """A path already present in the CasADi path must not be prepended again."""
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = "/custom/path"
+
+        # No new paths to add, so setCasadiPath must not be called and no log emitted.
+        with self.assertNoLogs("rtctools", level=logging.DEBUG):
+            _configure_extra_casadi_path(logger)
+
+        mock_casadi.GlobalOptions.setCasadiPath.assert_not_called()
+
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": f"/path/one{os.pathsep}/path/two"})
+    @patch("rtctools.util.casadi")
+    def test_multi_path_env_var_prepends_all(self, mock_casadi):
+        """Multiple paths in the env var are all prepended in order."""
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = "/casadi/default"
+
+        with self.assertLogs("rtctools", level=logging.DEBUG):
+            _configure_extra_casadi_path(logger)
+
+        call_args = mock_casadi.GlobalOptions.setCasadiPath.call_args.args[0]
+        self.assertEqual(call_args.split(os.pathsep), ["/path/one", "/path/two", "/casadi/default"])
+
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": f"/path/one{os.pathsep}/path/two"})
+    @patch("rtctools.util.casadi")
+    def test_multi_path_env_var_is_idempotent(self, mock_casadi):
+        """Calling twice with the same paths must not produce duplicates.
+
+        On the second call all entries are already in the CasADi path, so
+        setCasadiPath must not be called again and no log must be emitted.
+        """
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = "/casadi/default"
+
+        with self.assertLogs("rtctools", level=logging.DEBUG):
+            _configure_extra_casadi_path(logger)
+
+        first_call_args = mock_casadi.GlobalOptions.setCasadiPath.call_args.args[0]
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = first_call_args
+
+        with self.assertNoLogs("rtctools", level=logging.DEBUG):
+            _configure_extra_casadi_path(logger)
+
+        mock_casadi.GlobalOptions.setCasadiPath.assert_called_once()
+
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": f"/path/one{os.pathsep}/path/one/"})
+    @patch("rtctools.util.casadi")
+    def test_trailing_slash_deduplication(self, mock_casadi):
+        """Paths that differ only by a trailing slash must be treated as duplicates.
+
+        The first occurrence is kept; the second (with trailing slash) is dropped.
+        """
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = ""
+
+        with self.assertLogs("rtctools", level=logging.DEBUG):
+            _configure_extra_casadi_path(logger)
+
+        call_args = mock_casadi.GlobalOptions.setCasadiPath.call_args.args[0]
+        parts = call_args.split(os.pathsep)
+        self.assertEqual(len(parts), 1)
+        self.assertEqual(parts[0], "/path/one")

--- a/tests/optimization/test_extra_casadipath.py
+++ b/tests/optimization/test_extra_casadipath.py
@@ -1,0 +1,82 @@
+import logging
+import os
+from unittest.mock import patch
+
+from rtctools.util import _configure_extra_casadi_path
+
+from ..test_case import TestCase
+
+logger = logging.getLogger("rtctools")
+
+
+class TestExtraCasadiPath(TestCase):
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": "/custom/path"})
+    @patch("rtctools.util.casadi")
+    def test_prepends_to_existing_path(self, mock_casadi):
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = "/casadi/default"
+
+        with self.assertLogs("rtctools", level=logging.INFO) as cm:
+            _configure_extra_casadi_path(logger)
+
+        call_args = mock_casadi.GlobalOptions.setCasadiPath.call_args.args[0]
+        self.assertEqual(call_args.split(os.pathsep), ["/custom/path", "/casadi/default"])
+        # assertLogs output format is "LEVEL:logger:message".
+        self.assertTrue(
+            any(call_args in r and r.startswith("INFO:") for r in cm.output),
+            f"Expected combined path in INFO log output, got: {cm.output}",
+        )
+
+    @patch("rtctools.util.casadi")
+    def test_empty_or_whitespace_env_var_does_nothing(self, mock_casadi):
+        """Empty and whitespace-only values must be treated as absent and result in no action."""
+        for value in ("", " "):
+            with self.subTest(value=repr(value)):
+                with patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": value}):
+                    with self.assertNoLogs("rtctools", level=logging.INFO):
+                        _configure_extra_casadi_path(logger)
+                    mock_casadi.GlobalOptions.getCasadiPath.assert_not_called()
+                    mock_casadi.GlobalOptions.setCasadiPath.assert_not_called()
+
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": "/custom/path"})
+    @patch("rtctools.util.casadi")
+    def test_no_separator_artefacts_when_existing_path_is_none(self, mock_casadi):
+        """getCasadiPath() returning None must not introduce separator artefacts."""
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = None
+        with self.assertLogs("rtctools", level=logging.INFO):
+            _configure_extra_casadi_path(logger)
+        call_args = mock_casadi.GlobalOptions.setCasadiPath.call_args.args[0]
+        self.assertEqual(call_args, "/custom/path")
+
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": "/custom/path"})
+    @patch("rtctools.util.casadi")
+    def test_no_separator_artefacts_when_existing_path_is_empty(self, mock_casadi):
+        """getCasadiPath() returning "" must not introduce separator artefacts."""
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = ""
+        with self.assertLogs("rtctools", level=logging.INFO):
+            _configure_extra_casadi_path(logger)
+        call_args = mock_casadi.GlobalOptions.setCasadiPath.call_args.args[0]
+        self.assertEqual(call_args, "/custom/path")
+
+    @patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": "/custom/path"})
+    @patch("rtctools.util.casadi")
+    def test_already_in_existing_path_is_not_prepended(self, mock_casadi):
+        """A path already present in the CasADi path must not be prepended again."""
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = "/custom/path"
+
+        with self.assertNoLogs("rtctools", level=logging.INFO):
+            _configure_extra_casadi_path(logger)
+
+        mock_casadi.GlobalOptions.setCasadiPath.assert_not_called()
+
+    @patch("rtctools.util.casadi")
+    def test_nonexistent_path_emits_warning(self, mock_casadi):
+        """A path that does not exist on disk must trigger a warning."""
+        mock_casadi.GlobalOptions.getCasadiPath.return_value = ""
+        nonexistent = "/does/not/exist/on/any/machine"
+        with patch.dict(os.environ, {"RTCTOOLS_EXTRA_CASADIPATH": nonexistent}):
+            with self.assertLogs("rtctools", level=logging.WARNING) as cm:
+                _configure_extra_casadi_path(logger)
+        self.assertTrue(
+            any(nonexistent in r and r.startswith("WARNING:") for r in cm.output),
+            f"Expected WARNING about nonexistent path, got: {cm.output}",
+        )


### PR DESCRIPTION
CasADi searches for solver plugins in CASADIPATH but only after its own installation directory, making it impossible to override bundled solvers using CASADIPATH alone.

This PR adds `RTCTOOLS_EXTRA_CASADIPATH`, an environment variable that prepends a custom directory to CasADi's plugin search path via `GlobalOptions.setCasadiPath()`. This allows users to use custom-built CasADi plugin wrappers (e.g. libcasadi_conic_highs) compiled against a different solver version than the one bundled with CasADi.

## Implementation
- `_configure_extra_casadi_path(logger)` called after logging setup in both `run_optimization_problem()` and `run_simulation_problem()`
- Deduplication via `os.path.normcase(os.path.normpath(...))` — handles trailing-slash variants and case differences on Windows
- `logger.warning()` for each path entry that does not exist on disk
- `logger.info()` logs the active search path so users can confirm the override is in effect
- 6 unit tests
- Documentation added under Optimization > Solver Configuration

## Limitations
The directory must contain a CasADi plugin wrapper, not just the raw solver library. The wrapper must be compiled with the same toolchain as CasADi and linked against the desired solver version. See documentation for details.

## Testing (Windows)
Two helper scripts verify the feature end-to-end. Save them next to the repo root and run with `uv run python`.

```
uv run python demo_highs_plugin_setup.py hide     # copies bundled DLLs to custom_solver/, hides originals
uv run python demo_bundled_highs.py               # sets RTCTOOLS_EXTRA_CASADIPATH, runs pumped-hydro example
uv run python demo_highs_plugin_setup.py restore  # put originals back (also done automatically by demo_bundled_highs.py)
```

`demo_bundled_highs.py` hides the bundled DLLs, solves the pumped hydropower example via `RTCTOOLS_EXTRA_CASADIPATH=custom_solver/`, and restores the originals in a `finally` block.

Expected log line:
```
INFO ... Setting CasADi plugin search path to '<repo>/custom_solver;...'
```

<details>
<summary>demo_highs_plugin_setup.py</summary>

```python
"""
Helper script to temporarily rename the CasADi bundled HiGHS plugin so that
the custom solver in custom_solver/ takes effect when running demo_highs_plugin.py.

Two modes of operation:

  1. custom_solver/ already exists with DLLs:
     hide    — rename bundled DLLs to .bak so the custom ones win
     restore — rename .bak files back to their original names

  2. custom_solver/ does not exist:
     hide    — copy bundled DLLs into custom_solver/, then rename them to .bak
     restore — rename .bak files back (custom_solver/ stays in place)

Usage
-----
    uv run python demo_highs_plugin_setup.py hide     # rename bundled plugin away
    uv run python demo_highs_plugin_setup.py restore  # put the name back
"""

import shutil
import sys
import casadi
from pathlib import Path

REPO_ROOT   = Path(__file__).parent
CASADI_DIR  = Path(casadi.__file__).parent
CUSTOM_DIR  = REPO_ROOT / "custom_solver"

DLLS = [
    "libcasadi_conic_highs.dll",
    "libhighs.dll",
]


def hide():
    # If custom_solver/ does not exist, populate it from the bundled copies first.
    if not CUSTOM_DIR.exists():
        CUSTOM_DIR.mkdir()
        for name in DLLS:
            src = CASADI_DIR / name
            if src.exists():
                shutil.copy2(src, CUSTOM_DIR / name)
                print(f"Copied: {src} -> {CUSTOM_DIR / name}")
            else:
                print(f"Warning: bundled {name} not found at {src}, skipping copy")

    # Rename bundled DLLs to .bak so they are no longer found by CasADi.
    hidden_any = False
    for name in DLLS:
        bundled = CASADI_DIR / name
        hidden  = CASADI_DIR / (name + ".bak")
        if hidden.exists():
            print(f"Already hidden: {hidden.name}")
            continue
        if not bundled.exists():
            print(f"Not found, nothing to hide: {bundled.name}")
            continue
        bundled.rename(hidden)
        print(f"Renamed: {bundled.name} -> {hidden.name}")
        hidden_any = True

    if not hidden_any:
        print("Nothing new was hidden.")


def restore():
    restored_any = False
    for name in DLLS:
        bundled = CASADI_DIR / name
        hidden  = CASADI_DIR / (name + ".bak")
        if bundled.exists():
            print(f"Already restored: {bundled.name}")
            continue
        if not hidden.exists():
            print(f"Not found, nothing to restore: {hidden.name}")
            continue
        hidden.rename(bundled)
        print(f"Restored: {hidden.name} -> {bundled.name}")
        restored_any = True

    if not restored_any:
        print("Nothing to restore.")


if __name__ == "__main__":
    commands = {"hide": hide, "restore": restore}
    if len(sys.argv) != 2 or sys.argv[1] not in commands:
        print(f"Usage: {sys.argv[0]} hide|restore")
        sys.exit(1)
    commands[sys.argv[1]]()
```

</details>

<details>
<summary>demo_bundled_highs.py</summary>

```python
"""
Demo: RTCTOOLS_EXTRA_CASADIPATH with the same HiGHS version as bundled with CasADi.

Verifies that RTCTOOLS_EXTRA_CASADIPATH works correctly when the bundled DLLs are
not present in the CasADi folder, loading them instead from custom_solver/.

The script hides the bundled DLLs, runs the example via RTCTOOLS_EXTRA_CASADIPATH,
and restores the bundled DLLs afterwards.

Prerequisites
-------------
Run once to populate custom_solver/ if it does not exist yet:

    uv run python demo_highs_plugin_setup.py hide
    uv run python demo_highs_plugin_setup.py restore

Usage
-----
    uv run python demo_bundled_highs.py
"""

import os
import sys
from pathlib import Path
from unittest.mock import patch

REPO_ROOT   = Path(__file__).parent
EXAMPLE_DIR = REPO_ROOT / "examples" / "pumped_hydropower_system"
CUSTOM_DIR  = REPO_ROOT / "custom_solver"

if not CUSTOM_DIR.exists():
    print("ERROR: custom_solver/ not found. Run 'uv run python demo_highs_plugin_setup.py hide' first to populate it.")
    sys.exit(1)

# Set PATH and RTCTOOLS_EXTRA_CASADIPATH before importing casadi.
os.environ["RTCTOOLS_EXTRA_CASADIPATH"] = str(CUSTOM_DIR)
os.environ["PATH"] = str(CUSTOM_DIR) + os.pathsep + os.environ.get("PATH", "")

import demo_highs_plugin_setup
demo_highs_plugin_setup.hide()

sys.path.insert(0, str(EXAMPLE_DIR / "src"))

from rtctools.util import run_optimization_problem

with patch("rtctools.util.run_optimization_problem"):
    from example import PumpStorage

try:
    run_optimization_problem(PumpStorage, base_folder=str(EXAMPLE_DIR))
finally:
    demo_highs_plugin_setup.restore()
```

</details>

## Follow-up
- [CasADi #4299](https://github.com/casadi/casadi/pull/4299): Update bundled HiGHS version. Once merged, users can extract the updated plugin wrapper from a newer CasADi build and use it with this feature.
- [CasADi #4340](https://github.com/casadi/casadi/issues/4340): Switch to `LoadLibraryEx` on Windows — once merged, the transitive solver DLL will resolve without needing `PATH` manipulation.
- Integration test: add a CI-based test once a plugin wrapper build is available in the pipeline.
