### PR TITLE
ci: run examples job on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Tests & Release
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 concurrency:
   group: "${{ github.ref }}"
@@ -103,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: python:${{ matrix.version }}
-    if: startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags')
     timeout-minutes: 30
     env:
       TOXENV: examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Tests & Release
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 concurrency:
   group: "${{ github.ref }}"
@@ -112,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: python:${{ matrix.version }}
-    if: startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags')
     timeout-minutes: 30
     env:
       TOXENV: examples


### PR DESCRIPTION

- The `examples-linux` job previously only ran on tag pushes, meaning example regressions could go undetected until release time
- Now examples also run on pull requests, providing earlier feedback
