### PR TITLE
ci: allow SonarQube scan step to fail without blocking CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
         path: coverage.xml
     - name: SonarQube Cloud Scan
       if: ${{ success() && (github.event_name == 'push' || github.event_name == 'pull_request') }}
+      continue-on-error: true
       uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432  # v8.0.0
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
After renabling the SonarQube workflow, the CI is failing due to a missing SONAR_TOKEN.. I made a requiest to the LF to set up the new SONAR_TOKEN toean. 
As a temporary measure until the token is regenerated for the new rtc-tools-org SonarCloud organization, we can add `continue-on-error: true` to the SonarQube Cloud Scan step so that an invalid or missing `SONAR_TOKEN` does not fail the coverage job. 