### PR TITLE
Move Sonar scan into a dedicated job and pin action SHAs 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,6 @@ jobs:
       TOXENV: coverage
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      with:
-        # Full history required for accurate Sonar SCM blame data
-        fetch-depth: 0
     - uses: ./.github/actions/setup-python
       with:
         dependency-groups: "tests"
@@ -100,10 +97,21 @@ jobs:
         name: coverage-report
         retention-days: 7
         path: coverage.xml
+
+  sonar:
+    needs: [coverage]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      with:
+        fetch-depth: 0
+    - name: Download coverage report
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+      with:
+        name: coverage-report
     - name: SonarQube Cloud Scan
-      if: ${{ success() && (github.event_name == 'push' || github.event_name == 'pull_request') }}
-      continue-on-error: true
       uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432  # v8.0.0
+      continue-on-error: true
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
     - uses: ./.github/actions/setup-python
       with:
         dependency-groups: "style"
@@ -32,12 +32,12 @@ jobs:
       image: python:3.10
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup-python
     - run: uv build
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       if: success()
       with:
         name: "${{ github.job }}"
@@ -69,7 +69,7 @@ jobs:
             resolution_mode: 'highest'
             label: ' (Newest Dependencies)'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
     - uses: ./.github/actions/setup-python
       with:
         dependency-groups: "tests"
@@ -85,7 +85,7 @@ jobs:
     env:
       TOXENV: coverage
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       with:
         # Full history required for accurate Sonar SCM blame data
         fetch-depth: 0
@@ -94,7 +94,7 @@ jobs:
         dependency-groups: "tests"
     - run: uv run tox -vv
     - name: Upload coverage report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       if: success()
       with:
         name: coverage-report
@@ -125,7 +125,7 @@ jobs:
         - '3.13'
         - '3.14'
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
     - uses: ./.github/actions/setup-python
       with:
         dependency-groups: "tests"
@@ -140,7 +140,7 @@ jobs:
       contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python


### PR DESCRIPTION
ci: pin action SHAs and move Sonar scan into a dedicated job

- Extract the SonarQube Cloud scan from the `coverage` job into a dedicated `sonar` job that depends on `coverage`, downloads the coverage artifact explicitly, and uses `fetch-depth: 0` for accurate SCM blame data
- Following software security guidelines, pin all GitHub Actions to exact commit SHAs for supply-chain security, standardizing to latest v4 releases (`actions/checkout` v4.3.1, `actions/upload-artifact` v4.6.2, `actions/download-artifact` v4.3.0)
