### PR TITLE
feat(core): raise actionable error messages for pymoca 0.11 MSL class not-found failures

### DIFF
--- a/src/rtctools/_internal/modelica_errors.py
+++ b/src/rtctools/_internal/modelica_errors.py
@@ -1,0 +1,73 @@
+import re
+
+# Matches pymoca ClassNotFoundError messages in both known phrasings:
+# - "Could not find class 'X'"  (pymoca >= 0.10)
+# - "Class 'X' not found"       (alternative phrasing)
+_MODELICA_PATTERN = re.compile(
+    r"(?:[Cc]ould not find class|[Cc]lass)\s+'?(Modelica\.[^\s'\"]+)'?(?:\s+not found)?"
+)
+_SI_ALIAS_PATTERN = re.compile(
+    r"(?:[Cc]ould not find class|[Cc]lass)\s+'?(SI\.[^\s'\"]+)'?(?:\s+not found)?"
+)
+
+
+def _extract_missing_class(msg: str, pattern: re.Pattern) -> str | None:
+    match = pattern.search(msg)
+    return match.group(1) if match else None
+
+
+def _msl_error(model_folder: str, missing: str, detail: str, original: Exception) -> RuntimeError:
+    return RuntimeError(
+        f"Failed to load Modelica model from '{model_folder}'.\n"
+        f"  Missing class: '{missing}'\n\n"
+        f"{detail}\n\n"
+        f"  Original error: {original}"
+    )
+
+
+def raise_if_missing_msl(error: Exception, model_folder: str) -> None:
+    """Re-raise with an actionable message if the error matches a known MSL failure pattern."""
+    msg = str(error)
+
+    # Bug 1: Modelica.* class not in rtc-tools-standard-library
+    missing = _extract_missing_class(msg, _MODELICA_PATTERN)
+    if missing:
+        pkg = ".".join(missing.split(".")[:2])
+        if pkg == "Modelica.Units":
+            raise _msl_error(
+                model_folder,
+                missing,
+                f"  'Modelica.Units' is included in 'rtc-tools-standard-library',"
+                f" but '{missing}' was not found.\n"
+                f"  The class may not be covered by the installed version"
+                f" of 'rtc-tools-standard-library'.\n"
+                f"  You can also add the missing .mo files manually via"
+                f" 'modelica_library_folders' in your problem class.",
+                error,
+            ) from error
+        raise _msl_error(
+            model_folder,
+            missing,
+            f"  '{pkg}' is not included in 'rtc-tools-standard-library'"
+            f" (currently only Modelica.Units is supported).\n"
+            f"  To resolve this, contribute the missing package to:\n"
+            f"    https://github.com/rtc-tools/rtc-tools-standard-library\n"
+            f"  Or add the .mo files manually via 'modelica_library_folders'"
+            f" in your problem class.",
+            error,
+        ) from error
+
+    # Bug 2: unresolved SI.* alias — assumes SI always means Modelica.Units.SI.
+    missing = _extract_missing_class(msg, _SI_ALIAS_PATTERN)
+    if missing:
+        fq = missing.replace("SI.", "Modelica.Units.SI.", 1)
+        raise _msl_error(
+            model_folder,
+            missing,
+            f"  Known pymoca >= 0.11 regression: 'import SI = Modelica.Units.SI'"
+            f" aliases are silently dropped.\n"
+            f"  Replace '{missing}' with '{fq}' and remove the alias"
+            f" in the library that defines it,\n"
+            f"  or downgrade to rtc-tools 2.7.x (pymoca 0.9.2).",
+            error,
+        ) from error

--- a/src/rtctools/_internal/pymoca_helpers.py
+++ b/src/rtctools/_internal/pymoca_helpers.py
@@ -1,0 +1,39 @@
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import pymoca.backends.casadi.api
+
+from rtctools._internal.modelica_errors import raise_if_missing_msl
+
+_logger = logging.getLogger("rtctools")
+
+
+def load_pymoca_model(
+    model_folder: str,
+    model_name: str,
+    compiler_options: Mapping[str, Any],
+    logger: logging.Logger | None = None,
+) -> Any:
+    """Load a pymoca model with cache-retry logic and actionable MSL error messages.
+
+    compiler_options is never mutated; a copy with cache=False is used for the retry.
+    """
+    if logger is None:
+        logger = _logger
+    try:
+        return pymoca.backends.casadi.api.transfer_model(model_folder, model_name, compiler_options)
+    except (RuntimeError, ModuleNotFoundError) as error:
+        raise_if_missing_msl(error, model_folder)
+        if not compiler_options.get("cache", False):
+            raise
+        compiler_options = {**compiler_options, "cache": False}
+        logger.warning(f"Loading model {model_name} using a cache file failed: {error}.")
+        logger.info(f"Compiling model {model_name}.")
+        try:
+            return pymoca.backends.casadi.api.transfer_model(
+                model_folder, model_name, compiler_options
+            )
+        except (ModuleNotFoundError, RuntimeError) as retry_error:
+            raise_if_missing_msl(retry_error, model_folder)
+            raise

--- a/src/rtctools/optimization/modelica_mixin.py
+++ b/src/rtctools/optimization/modelica_mixin.py
@@ -6,12 +6,12 @@ from importlib import metadata as importlib_metadata
 import casadi as ca
 import numpy as np
 import pymoca
-import pymoca.backends.casadi.api
 
 from rtctools._internal.alias_tools import AliasDict
 from rtctools._internal.caching import cached
 from rtctools._internal.casadi_helpers import substitute_in_external
 from rtctools._internal.ensemble_bounds_decorator import ensemble_bounds_check
+from rtctools._internal.pymoca_helpers import load_pymoca_model
 
 from .optimization_problem import OptimizationProblem
 from .timeseries import Timeseries
@@ -51,19 +51,9 @@ class ModelicaMixin(OptimizationProblem):
 
         compiler_options = self.compiler_options()
         logger.info(f"Loading/compiling model {model_name}.")
-        try:
-            self.__pymoca_model = pymoca.backends.casadi.api.transfer_model(
-                kwargs["model_folder"], model_name, compiler_options
-            )
-        except (RuntimeError, ModuleNotFoundError) as error:
-            if not compiler_options.get("cache", False):
-                raise error
-            compiler_options["cache"] = False
-            logger.warning(f"Loading model {model_name} using a cache file failed: {error}.")
-            logger.info(f"Compiling model {model_name}.")
-            self.__pymoca_model = pymoca.backends.casadi.api.transfer_model(
-                kwargs["model_folder"], model_name, compiler_options
-            )
+        self.__pymoca_model = load_pymoca_model(
+            kwargs["model_folder"], model_name, compiler_options, logger
+        )
 
         # Extract the CasADi MX variables used in the model
         self.__mx = {}

--- a/src/rtctools/simulation/simulation_problem.py
+++ b/src/rtctools/simulation/simulation_problem.py
@@ -9,11 +9,11 @@ from importlib import metadata as importlib_metadata
 import casadi as ca
 import numpy as np
 import pymoca
-import pymoca.backends.casadi.api
 
 from rtctools._internal.alias_tools import AliasDict
 from rtctools._internal.caching import cached
 from rtctools._internal.debug_check_helpers import DebugLevel
+from rtctools._internal.pymoca_helpers import load_pymoca_model
 from rtctools.data.storage import DataStoreAccessor
 
 logger = logging.getLogger("rtctools")
@@ -84,19 +84,9 @@ class SimulationProblem(DataStoreAccessor):
         # Load model from pymoca backend
         compiler_options = self.compiler_options()
         logger.info(f"Loading/compiling model {model_name}.")
-        try:
-            self.__pymoca_model = pymoca.backends.casadi.api.transfer_model(
-                kwargs["model_folder"], model_name, compiler_options
-            )
-        except RuntimeError as error:
-            if compiler_options.get("cache", False):
-                raise error
-            compiler_options["cache"] = False
-            logger.warning(f"Loading model {model_name} using a cache file failed: {error}.")
-            logger.info(f"Compiling model {model_name}.")
-            self.__pymoca_model = pymoca.backends.casadi.api.transfer_model(
-                kwargs["model_folder"], model_name, compiler_options
-            )
+        self.__pymoca_model = load_pymoca_model(
+            kwargs["model_folder"], model_name, compiler_options, logger
+        )
 
         # Extract the CasADi MX variables used in the model
         self.__mx = {}
@@ -1164,7 +1154,7 @@ class SimulationProblem(DataStoreAccessor):
         NOTE: Due to backwards compatibility for allowing parameters to be set
         with set_var() instead of overriding parameters(), this method can
         return a symbolic value for nominals defined in the Modelica file. It
-        can only do so until the initializion() method in this class is
+        can only do so until the initialize() method in this class is
         called/completed, after which it will return numeric values only.
         """
         return self.__nominals.get(variable, 1.0)
@@ -1194,7 +1184,7 @@ class SimulationProblem(DataStoreAccessor):
                 pass
             else:
                 if logger.getEffectiveLevel() == logging.DEBUG:
-                    logger.debug(f"Read intial state for {variable}")
+                    logger.debug(f"Read initial state for {variable}")
 
         return initial_state_dict
 

--- a/tests/internal/test_modelica_errors.py
+++ b/tests/internal/test_modelica_errors.py
@@ -1,0 +1,43 @@
+import unittest
+
+from rtctools._internal.modelica_errors import raise_if_missing_msl
+
+
+class TestRaiseIfMissingMsl(unittest.TestCase):
+    def _call(self, msg):
+        raise_if_missing_msl(RuntimeError(msg), "/some/model/folder")
+
+    # Both pymoca phrasings should reach the same branch and carry the same payload.
+    def _assert_non_units_package(self, msg):
+        with self.assertRaises(RuntimeError) as ctx:
+            self._call(msg)
+        out = str(ctx.exception)
+        self.assertIn("Modelica.SIunits.Velocity", out)
+        self.assertIn("is not included in", out)
+        self.assertIn("rtc-tools-standard-library", out)
+        self.assertIn("https://github.com/rtc-tools/rtc-tools-standard-library", out)
+
+    def test_missing_non_units_package_could_not_find_phrasing(self):
+        self._assert_non_units_package("Could not find class 'Modelica.SIunits.Velocity'")
+
+    def test_missing_non_units_package_class_not_found_phrasing(self):
+        self._assert_non_units_package("Class 'Modelica.SIunits.Velocity' not found")
+
+    def test_missing_modelica_units_class_raises_version_message(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self._call("Could not find class 'Modelica.Units.SI.UnknownType'")
+        out = str(ctx.exception)
+        self.assertIn("Modelica.Units.SI.UnknownType", out)
+        self.assertIn("Modelica.Units", out)
+        self.assertNotIn("is not included in", out)
+
+    def test_si_alias_regression_raises_with_expanded_name(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self._call("Could not find class 'SI.VolumeFlowRate'")
+        out = str(ctx.exception)
+        self.assertIn("SI.VolumeFlowRate", out)
+        self.assertIn("Modelica.Units.SI.VolumeFlowRate", out)
+        self.assertIn("regression", out)
+
+    def test_non_matching_message_does_not_raise(self):
+        self._call("Simulation failed due to numerical instability")

--- a/tests/internal/test_pymoca_helpers.py
+++ b/tests/internal/test_pymoca_helpers.py
@@ -1,0 +1,115 @@
+import logging
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from rtctools._internal.pymoca_helpers import load_pymoca_model
+
+PYMOCA_TRANSFER_MODEL = (
+    "rtctools._internal.pymoca_helpers.pymoca.backends.casadi.api.transfer_model"
+)
+MODEL_FOLDER = "/some/model"
+MODEL_NAME = "MyModel"
+LOGGER = logging.getLogger("test")
+
+
+def _opts(cache=True):
+    return {"cache": cache}
+
+
+class TestLoadPymocaModel(unittest.TestCase):
+    def test_success_returns_model(self):
+        model = MagicMock()
+        with patch(PYMOCA_TRANSFER_MODEL, return_value=model) as mock_transfer:
+            result = load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(), LOGGER)
+        self.assertIs(result, model)
+        mock_transfer.assert_called_once_with(MODEL_FOLDER, MODEL_NAME, _opts())
+
+    def test_non_cache_error_raises_immediately(self):
+        with patch(PYMOCA_TRANSFER_MODEL, side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(cache=False), LOGGER)
+
+    def test_module_not_found_error_no_cache_raises_immediately(self):
+        with patch(PYMOCA_TRANSFER_MODEL, side_effect=ModuleNotFoundError("missing module")):
+            with self.assertRaises(ModuleNotFoundError):
+                load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(cache=False), LOGGER)
+
+    def test_module_not_found_error_cache_retries(self):
+        model = MagicMock()
+        with patch(
+            PYMOCA_TRANSFER_MODEL, side_effect=[ModuleNotFoundError("stale cache"), model]
+        ) as mock_transfer:
+            result = load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(cache=True), LOGGER)
+        self.assertIs(result, model)
+        self.assertEqual(
+            mock_transfer.call_args_list,
+            [
+                call(MODEL_FOLDER, MODEL_NAME, {"cache": True}),
+                call(MODEL_FOLDER, MODEL_NAME, {"cache": False}),
+            ],
+        )
+
+    def test_cache_failure_retries_without_cache(self):
+        model = MagicMock()
+        with patch(
+            PYMOCA_TRANSFER_MODEL, side_effect=[RuntimeError("stale cache"), model]
+        ) as mock_transfer:
+            result = load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(cache=True), LOGGER)
+        self.assertIs(result, model)
+        self.assertEqual(
+            mock_transfer.call_args_list,
+            [
+                call(MODEL_FOLDER, MODEL_NAME, {"cache": True}),
+                call(MODEL_FOLDER, MODEL_NAME, {"cache": False}),
+            ],
+        )
+
+    def test_cache_failure_does_not_mutate_compiler_options(self):
+        model = MagicMock()
+        original_opts = {"cache": True}
+        with patch(PYMOCA_TRANSFER_MODEL, side_effect=[RuntimeError("stale cache"), model]):
+            load_pymoca_model(MODEL_FOLDER, MODEL_NAME, original_opts, LOGGER)
+        self.assertTrue(original_opts["cache"])
+
+    def test_retry_failure_reraises(self):
+        with patch(
+            PYMOCA_TRANSFER_MODEL,
+            side_effect=[RuntimeError("stale cache"), RuntimeError("compile fail")],
+        ):
+            with self.assertRaises(RuntimeError):
+                load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(cache=True), LOGGER)
+
+    def test_module_not_found_error_retry_failure_reraises(self):
+        with patch(
+            PYMOCA_TRANSFER_MODEL,
+            side_effect=[ModuleNotFoundError("stale cache"), ModuleNotFoundError("still missing")],
+        ):
+            with self.assertRaises(ModuleNotFoundError):
+                load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(cache=True), LOGGER)
+
+    def test_msl_error_on_first_call_raises_runtime_error(self):
+        with patch(
+            PYMOCA_TRANSFER_MODEL,
+            side_effect=RuntimeError("Could not find class 'Modelica.SIunits.Height'"),
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(cache=False), LOGGER)
+        self.assertIn(MODEL_FOLDER, str(ctx.exception))
+
+    def test_msl_error_on_retry_raises_runtime_error(self):
+        with patch(
+            PYMOCA_TRANSFER_MODEL,
+            side_effect=[
+                RuntimeError("stale cache"),
+                RuntimeError("Could not find class 'SI.VolumeFlowRate'"),
+            ],
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(cache=True), LOGGER)
+        self.assertIn(MODEL_FOLDER, str(ctx.exception))
+
+    def test_default_logger_used_when_not_provided(self):
+        model = MagicMock()
+        with patch(PYMOCA_TRANSFER_MODEL, side_effect=[RuntimeError("stale cache"), model]):
+            result = load_pymoca_model(MODEL_FOLDER, MODEL_NAME, _opts(cache=True))
+        self.assertIs(result, model)


### PR DESCRIPTION
pymoca 0.10+ dropped the built-in Modelica namespace. Modelica Standard Library types must now be provided explicitly, e.g. via rtc-tools-standard-library.  When a class is missing, pymoca raises a cryptic ClassNotFoundError with no guidance on how to fix it. This PR intercepts those errors at both call sites (ModelicaMixin and SimulationProblem) and re-raises with actionable messages.

Two failure patterns are handled:

- Missing Modelica.* package (e.g. Modelica.SIunits.* not in rtc-tools-standard-library): directs the user to contribute the
  package or add .mo files manually via modelica_library_folders.
- Unresolved SI.* alias (pymoca >= 0.11 regression: `import SI = Modelica.Units.SI` aliases are silently dropped): expands the alias to the fully-qualified name and directs the user to update the library or downgrade to rtc-tools 2.7.x.

Follow-up

- rtc-tools-standard-library: add Modelica/SIunits.mo (MSL 3.2.3) to resolve the missing Modelica.SIunits.* failures.
- rtc-tools-channel-flow: expand `SI.X` → `Modelica.Units.SI.X` across multiple files to resolve the alias regression without requiring a pymoca downgrade.

Supersedes #1762 (closed). Key differences: adds `SI.*` alias pattern (multiple occurrences in `rtctools_channel_flow`), hooks both `ModelicaMixin`   and `SimulationProblem` (including retry paths), and drops the migration CLI.

Resolves #1798 and #1795 
