### PR TITLE
goal-programming: raise actionable error when function_range cannot be derived

### DIFF
--- a/src/rtctools/optimization/goal_programming_mixin_base.py
+++ b/src/rtctools/optimization/goal_programming_mixin_base.py
@@ -396,9 +396,9 @@ class StateGoal(Goal):
         if self.has_target_bounds:
             try:
                 if optimization_problem.ensemble_specific_bounds:
-                    bounds = optimization_problem.bounds(0)
-                    bounds_state_ref = bounds[self.state]
                     if np.array_equal(self.function_range, (np.nan, np.nan), equal_nan=True):
+                        bounds = optimization_problem.bounds(0)
+                        bounds_state_ref = bounds[self.state]
                         # If the user has not set the function range themselves, we
                         # try and set it automatically. This is only possible if the
                         # bounds are the same for all ensemble members.
@@ -406,10 +406,8 @@ class StateGoal(Goal):
                             bounds_state_ensemble = optimization_problem.bounds(ensemble_member)[
                                 self.state
                             ]
-                            # First, check if the types are equal, and then check if the values are
-                            # equal. For Timeseries and floats, we can do `==` comparison, for
-                            # arrays we need to use np.all. To simplify we wrap the `==` for floats
-                            # in an `np.all` as well.
+                            # np.all(a == b) works for all bound types: tuples and arrays return
+                            # element-wise booleans; Timeseries.__eq__ returns a single bool.
                             if type(bounds_state_ref) is not type(
                                 bounds_state_ensemble
                             ) or not np.all(bounds_state_ref == bounds_state_ensemble):
@@ -417,9 +415,11 @@ class StateGoal(Goal):
                                     f"Bounds for state {self.state} are not the same for all "
                                     f"ensemble members; please set the function_range explicitly"
                                 )
+                        self.function_range = bounds[self.state]
                 else:
-                    bounds = optimization_problem.bounds()
-                self.function_range = bounds[self.state]
+                    if np.array_equal(self.function_range, (np.nan, np.nan), equal_nan=True):
+                        bounds = optimization_problem.bounds()
+                        self.function_range = bounds[self.state]
             except KeyError:
                 raise Exception(f"State {self.state} has no bounds or does not exist in the model.")
 
@@ -653,7 +653,10 @@ class _GoalProgrammingMixinBase(OptimizationProblem, metaclass=ABCMeta):
                 pass
             elif goal.has_target_bounds:
                 if not np.all(np.isfinite(m)) or not np.all(np.isfinite(M)):
-                    raise Exception(f"No function range specified for goal {goal}")
+                    raise Exception(
+                        f"Could not determine a finite function_range for goal {goal}.\n"
+                        f"  Fix: set function_range explicitly, e.g. function_range = (min, max)."
+                    )
 
                 if np.any(m >= M):
                     raise Exception(f"Invalid function range for goal {goal}")

--- a/tests/optimization/test_goal_programming.py
+++ b/tests/optimization/test_goal_programming.py
@@ -927,7 +927,7 @@ class TestGoalProgrammingInvalidGoals(TestCase):
 
     def test_function_range_present(self):
         self.problem._goals = [InvalidGoal(target_min=2.0)]
-        with self.assertRaisesRegex(Exception, "No function range specified"):
+        with self.assertRaisesRegex(Exception, "Could not determine a finite function_range"):
             self.problem.optimize()
 
     def test_function_range_valid(self):
@@ -1174,4 +1174,85 @@ class TestGoalProgrammingEnsembleBoundsAutoSetFunctionRange(TestCase):
             problem.bounds(0).get("x"),
             f"Automatically set function_range is incorrect. "
             f"Expected {problem.bounds(0).get('x')}, got {function_range}",
+        )
+
+
+class ModelForInfiniteBounds(EnsembleBoundsGoalProgrammingModel):
+    """Model whose bounds() yields (-inf, inf) for the goal's state, mimicking a
+    model that did not provide finite min/max (e.g. the pymoca >= 0.11 regression
+    that drops min/max modifiers)."""
+
+    def bounds(self, ensemble_member: int):
+        bounds = super().bounds(ensemble_member)
+        bounds["x"] = (-np.inf, np.inf)
+        return bounds
+
+    def path_goals(self):
+        return [EnsembleBoundsStateGoal(self)]
+
+
+class CriticalEnsembleBoundsStateGoal(EnsembleBoundsStateGoal):
+    """Critical variant: function_range is not used for critical goals, so an
+    infinite derived range must NOT raise."""
+
+    critical = True
+
+
+class ModelForInfiniteBoundsCritical(ModelForInfiniteBounds):
+    def path_goals(self):
+        return [CriticalEnsembleBoundsStateGoal(self)]
+
+
+class TestGoalProgrammingInfiniteDerivedFunctionRange(TestCase):
+    def test_actionable_error_when_derived_function_range_is_infinite(self):
+        """
+        When function_range is auto-derived from bounds() but those bounds are not
+        finite, the goal should fail with an actionable message pointing the user
+        at function_range (raised in validate_goals()), rather than the previous
+        generic "No function range specified" error.
+        """
+        problem = ModelForInfiniteBounds()
+        with self.assertRaisesRegex(Exception, "Could not determine a finite function_range"):
+            problem.optimize()
+
+    def test_critical_goal_with_infinite_range_does_not_raise(self):
+        """
+        function_range is not used for critical goals, so an infinite derived
+        range must not trigger the function_range error (backwards compatibility).
+        """
+        problem = ModelForInfiniteBoundsCritical()
+        try:
+            problem.optimize()
+        except Exception as e:
+            if "function_range" in str(e):
+                self.fail(
+                    "Critical goal with infinite derived function_range should not "
+                    f"raise the function_range error, but got: {e}"
+                )
+            raise
+        # Confirm the goal actually ran to completion with an infinite derived range,
+        # so this test cannot pass vacuously if a fixture change makes bounds finite.
+        self.assertIsNotNone(problem.objective_value)
+
+
+class ModelForExplicitFunctionRangeWithInfiniteBounds(ModelForInfiniteBounds):
+    """Model whose bounds() yields (-inf, inf) but the goal has an explicit function_range.
+    Verifies that an explicit function_range is not overwritten by bounds()."""
+
+    def path_goals(self):
+        return [ExplicitFunctionRangeGoal(self)]
+
+
+class TestGoalProgrammingExplicitFunctionRangeNotOverwritten(TestCase):
+    def test_explicit_function_range_is_retained(self):
+        """
+        StateGoal.__init__ must not overwrite an explicitly-set function_range with
+        the value from bounds(), even when bounds() returns (-inf, inf).
+        """
+        problem = ModelForExplicitFunctionRangeWithInfiniteBounds()
+        problem.optimize()
+        self.assertEqual(
+            problem.path_goals()[0].function_range,
+            (-20.0, 20.0),
+            "Explicit function_range was overwritten by bounds() — guard missing or broken.",
         )


### PR DESCRIPTION

- Replace the generic "No function range specified" error with a message that names the goal and points at the fix: set function_range explicitly.

- Fix StateGoal.__init__ unconditionally overwriting an explicit function_range with bounds() — the advice in the error message would otherwise be broken for the goals that hit it. As a side effect, prevents a spurious KeyError when ensemble_specific_bounds=True and the state has no bounds entry but function_range is already explicit.
 
- Add tests: actionable error on infinite derived range, critical goal exemption, and explicit function_range retained after construction.