### PR TITLE
build: pin pymoca to 0.9.* and fix download URL scheme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "casadi >= 3.6.3, < 3.8, !=3.6.6",
     "numpy >= 1.21.2",
     "scipy >= 1.7.2",
-    "pymoca == 0.11.*",
+    "pymoca >= 0.9.1, == 0.9.*",
     "rtc-tools-channel-flow >= 1.2.0",
     "rtc-tools-standard-library >= 0.1.2",
     "defusedxml >= 0.7.0",
@@ -73,7 +73,7 @@ tests = [
 
 [project.urls]
 Homepage = "https://oss.deltares.nl/web/rtc-tools/home"
-Download = "http://github.com/rtc-tools/rtc-tools/"
+Download = "https://github.com/rtc-tools/rtc-tools/"
 
 [project.scripts]
 rtc-tools-download-examples = "rtctools.rtctoolsapp:download_examples"

--- a/uv.lock
+++ b/uv.lock
@@ -1309,16 +1309,16 @@ wheels = [
 
 [[package]]
 name = "pymoca"
-version = "0.11.2"
+version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/f3/04e097011b86e001c14075aac6bd3b4d3044fa432713ce2770de0c34eb44/pymoca-0.11.2.tar.gz", hash = "sha256:1351a7b421559dc15f9fbc63517d3bb9cf64aecb3499168e6ecc14275bdb77fe", size = 122156, upload-time = "2026-03-12T18:09:45.65Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/2abf5d074b6e69c190aac8fd6d2f732b2fcba0b73229776a18d4cace074f/pymoca-0.9.2.tar.gz", hash = "sha256:bb0f1368e67f7bb876c3cb3a468e4d3a87a28e7624adb7483b39a22274b730e0", size = 111886, upload-time = "2025-01-28T15:44:25.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/f0/c41e075401101f22b7304918c626d8edd7c63b0180976ae45924d0f88b2f/pymoca-0.11.2-py3-none-any.whl", hash = "sha256:63135a3fdadcb7eeb29f93774dcec0656a378358e66950bdb3714fa39547fe0a", size = 124302, upload-time = "2026-03-12T18:09:44.627Z" },
+    { url = "https://files.pythonhosted.org/packages/24/55/ecf41c62849b27684431f096872216427d6190dec2ee8d2c2550669d7395/pymoca-0.9.2-py3-none-any.whl", hash = "sha256:13b96bd877def818fba22f43b1b3916470b573e569c7e7f1bd98a8990b9b60d3", size = 113709, upload-time = "2025-01-28T15:44:22.626Z" },
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ requires-dist = [
     { name = "netcdf4", marker = "extra == 'all'" },
     { name = "netcdf4", marker = "extra == 'netcdf'" },
     { name = "numpy", specifier = ">=1.21.2" },
-    { name = "pymoca", specifier = "==0.11.*" },
+    { name = "pymoca", specifier = "==0.9.*,>=0.9.1" },
     { name = "rtc-tools-channel-flow", specifier = ">=1.2.0" },
     { name = "rtc-tools-standard-library", specifier = ">=0.1.2" },
     { name = "scipy", specifier = ">=1.7.2" },


### PR DESCRIPTION
Pymoca was bumped to 0.11.* in a previous commit (e1347b6). 

During testing, I found three regressions in Pymoca that break existing tests and examples.

1. KeyError: 'Deltares' — fully-qualified component references fail during code generation in cascading_channels and similar models. This is specific to how RTC-Tools models are structured and will need to be fixed in our codebase.
2. ClassNotFoundError: SI.VolumeFlowRate — import SI = Modelica.Units.SI aliases not resolved in partial models (goal_programming, mixed_integer). Addressed by [rtc-tools-channel-flow fix](PR in progress) expanding SI.X → Modelica.Units.SI.X.
3. Incorrect bounds derivation causing function_range to be unresolvable in StateGoals, addressed with actionable error messages in #1801.

Changes in this PR:

- Pin pymoca back to 0.9.* in pyproject.toml and regenerate uv.lock
- Fix Download URL scheme from http to https in pyproject.toml

The 0.11.* migration can be re-attempted once the following PRs land:
- #1796 — actionable error messages for pymoca 0.11 MSL class-not-found failures
- #1801 — actionable error when function_range cannot be derived
- rtc-tools-standard-library#4 (https://github.com/rtc-tools/rtc-tools-standard-library/pull/4) — add Modelica/SIunits.mo to resolve missing Modelica.SIunits.* failures
- rtc-tools-channel-flow: expand SI.X → Modelica.Units.SI.X (PR in progress)