### PR TITLE
fix(rtctoolsapp): download examples from release zipball

### DIFF
--- a/src/rtctools/rtctoolsapp.py
+++ b/src/rtctools/rtctoolsapp.py
@@ -1,12 +1,34 @@
 import importlib.resources
 import logging
 import os
+import re
 import shutil
 import sys
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 
 import rtctools
+
+
+def _zipball_version(version: str) -> str:
+    """Return the nearest GitHub zipball version for an RTC-Tools version string."""
+
+    version = version.split("+", 1)[0]
+
+    match = re.match(
+        r"^(?P<base>\d+(?:\.\d+)*)(?:(?P<pre>a|b|rc)(?P<pre_num>\d+))?(?:\.post\d+)?(?:\.dev\d+)?$",
+        version,
+    )
+    if not match:
+        return version
+
+    release_version = match.group("base")
+    pre = match.group("pre")
+    if pre is not None:
+        release_version += f"{pre}{match.group('pre_num')}"
+
+    return release_version
+
 
 logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("rtctools")
@@ -72,7 +94,7 @@ def copy_libraries(*args):
         except OSError:
             sys.exit(f"Failed merging the libraries in package '{tld}'")
 
-    sys.exit(f"Succesfully copied all library folders to '{dst.resolve()}'")
+    sys.exit(f"Successfully copied all library folders to '{dst.resolve()}'")
 
 
 def download_examples(*args):
@@ -94,28 +116,50 @@ def download_examples(*args):
     from zipfile import ZipFile
 
     version = rtctools.__version__
+    release_version = _zipball_version(version)
+    if release_version != version:
+        logger.info(
+            f"Using RTC-Tools version {release_version} "
+            f"(resolved from {version}) to download examples."
+        )
+    else:
+        logger.info(f"Using RTC-Tools version {release_version} to download examples.")
+
+    local_filename = None
     try:
-        url = f"https://github.com/rtc-tools/rtc-tools/zipball/{version}"
+        url = f"https://github.com/rtc-tools/rtc-tools/zipball/{release_version}"
 
         opener = urllib.request.build_opener()
         urllib.request.install_opener(opener)
         # The security warning can be dismissed as the url variable is hardcoded to a remote.
         local_filename, _ = urllib.request.urlretrieve(url)  # nosec
     except HTTPError:
-        sys.exit(f"Could not found examples for RTC-Tools version {version}.")
-
-    with ZipFile(local_filename, "r") as z:
-        target = path / "rtc-tools-examples"
-        zip_folder_name = next(x for x in z.namelist() if x.startswith("Deltares-rtc-tools-"))
-        prefix = "{}/examples/".format(zip_folder_name.rstrip("/"))
-        members = [x for x in z.namelist() if x.startswith(prefix)]
-        z.extractall(members=members)
-        shutil.move(prefix, target)
-        shutil.rmtree(zip_folder_name)
-
-        sys.exit(f"Succesfully downloaded the RTC-Tools examples to '{target.resolve()}'")
+        sys.exit(f"Could not find examples for RTC-Tools version {release_version}.")
 
     try:
-        os.remove(local_filename)
-    except OSError:
-        pass
+        with ZipFile(local_filename, "r") as z:
+            import tempfile
+
+            target = path / "rtc-tools-examples"
+            zip_folder_name = next(
+                (name.split("/", 1)[0] for name in z.namelist() if name and "/" in name),
+                None,
+            )
+            if zip_folder_name is None:
+                sys.exit("Downloaded archive is malformed or empty.")
+
+            prefix = f"{zip_folder_name}/examples/"
+            members = [x for x in z.namelist() if x.startswith(prefix)]
+
+            with tempfile.TemporaryDirectory(dir=path) as extract_dir:
+                extract_dir = Path(extract_dir)
+                z.extractall(path=extract_dir, members=members)
+                shutil.move(str(extract_dir / zip_folder_name / "examples"), target)
+
+                sys.exit(f"Successfully downloaded the RTC-Tools examples to '{target.resolve()}'")
+    finally:
+        if local_filename is not None:
+            try:
+                os.remove(local_filename)
+            except OSError:
+                pass

--- a/tests/test_rtctoolsapp.py
+++ b/tests/test_rtctoolsapp.py
@@ -1,0 +1,125 @@
+import tempfile
+import unittest
+import urllib.request
+import zipfile
+from contextlib import nullcontext
+from pathlib import Path
+from unittest.mock import patch
+
+import rtctools
+from rtctools import rtctoolsapp
+
+
+class TestDownloadExamples(unittest.TestCase):
+    def _run_download_examples(self, version, zip_entries, capture_logs=False):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            download_dir = tmp_path / "downloads"
+            download_dir.mkdir()
+
+            zip_path = tmp_path / "repo.zip"
+            with zipfile.ZipFile(zip_path, "w") as zf:
+                for archive_name, content in zip_entries:
+                    zf.writestr(archive_name, content)
+
+            requested_urls = []
+
+            def fake_urlretrieve(url):
+                requested_urls.append(url)
+                return str(zip_path), None
+
+            def fake_exit(message=0):
+                raise SystemExit(message)
+
+            with (
+                patch.object(rtctools, "__version__", version),
+                patch.object(urllib.request, "build_opener", return_value=object()),
+                patch.object(urllib.request, "install_opener", return_value=None),
+                patch.object(urllib.request, "urlretrieve", side_effect=fake_urlretrieve),
+                patch.object(rtctoolsapp.sys, "exit", side_effect=fake_exit),
+            ):
+                if capture_logs:
+                    log_context = self.assertLogs("rtctools", level="INFO")
+                else:
+                    log_context = nullcontext(None)
+
+                with log_context as logs:
+                    with self.assertRaises(SystemExit) as ctx:
+                        rtctoolsapp.download_examples(str(download_dir))
+
+            return {
+                "exception": str(ctx.exception),
+                "requested_urls": requested_urls,
+                "zip_removed": not zip_path.exists(),
+                "example_exists": (download_dir / "rtc-tools-examples" / "example.txt").exists(),
+                "logs": "\n".join(logs.output) if capture_logs else None,
+            }
+
+    def test_download_examples_uses_release_version_and_logs(self):
+        result = self._run_download_examples(
+            version="2.7.2+9.g0f23240",
+            zip_entries=[("rtc-tools-rtc-tools-abc123/examples/example.txt", "hello")],
+            capture_logs=True,
+        )
+
+        self.assertIn("Successfully downloaded the RTC-Tools examples", result["exception"])
+        self.assertEqual(
+            result["requested_urls"], ["https://github.com/rtc-tools/rtc-tools/zipball/2.7.2"]
+        )
+        self.assertTrue(result["zip_removed"])
+        self.assertTrue(result["example_exists"])
+        self.assertIn(
+            (
+                "Using RTC-Tools version 2.7.2 "
+                "(resolved from 2.7.2+9.g0f23240) to download examples."
+            ),
+            result["logs"],
+        )
+
+    def test_download_examples_uses_release_version_verbatim_when_already_released(self):
+        result = self._run_download_examples(
+            version="2.7.3",
+            zip_entries=[("rtc-tools-rtc-tools-2.7.3/examples/example.txt", "hello")],
+            capture_logs=True,
+        )
+
+        self.assertIn("Successfully downloaded the RTC-Tools examples", result["exception"])
+        self.assertEqual(
+            result["requested_urls"], ["https://github.com/rtc-tools/rtc-tools/zipball/2.7.3"]
+        )
+        self.assertTrue(result["zip_removed"])
+        self.assertTrue(result["example_exists"])
+        self.assertIn(
+            "Using RTC-Tools version 2.7.3 to download examples.",
+            result["logs"],
+        )
+
+    def test_download_examples_resolves_post_dev_local_version_to_prerelease_tag(self):
+        result = self._run_download_examples(
+            version="2.8.0a2.post1.dev63+g94b832a.d20260616",
+            zip_entries=[("rtc-tools-rtc-tools-2.8.0a2/examples/example.txt", "hello")],
+            capture_logs=True,
+        )
+
+        self.assertIn("Successfully downloaded the RTC-Tools examples", result["exception"])
+        self.assertEqual(
+            result["requested_urls"], ["https://github.com/rtc-tools/rtc-tools/zipball/2.8.0a2"]
+        )
+        self.assertTrue(result["zip_removed"])
+        self.assertTrue(result["example_exists"])
+        self.assertIn(
+            (
+                "Using RTC-Tools version 2.8.0a2 "
+                "(resolved from 2.8.0a2.post1.dev63+g94b832a.d20260616) to download examples."
+            ),
+            result["logs"],
+        )
+
+    def test_download_examples_handles_empty_archive(self):
+        result = self._run_download_examples(version="2.7.3", zip_entries=[])
+
+        self.assertEqual(
+            result["requested_urls"], ["https://github.com/rtc-tools/rtc-tools/zipball/2.7.3"]
+        )
+        self.assertIn("Downloaded archive is malformed or empty.", result["exception"])
+        self.assertTrue(result["zip_removed"])


### PR DESCRIPTION
Resolve the GitHub zipball version to the nearest release tag before downloading examples. This avoids failures for development versions such as 2.7.2+9.g0f23240, where no zipball is published. Also log the resolved release version used for the download.