### PR TITLE
docs(readme): add TeamCity, PyPI, LFX Health Score, and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
   <img src="doc/images/rtc-tools-horizontal-color.svg" alt="RTC-Tools logo" width="70%">
 </p>
 
-[![Pipeline](https://github.com/rtc-tools/rtc-tools/actions/workflows/ci.yml/badge.svg)](
-    https://github.com/rtc-tools/rtc-tools/actions/workflows/ci.yml
-)
+[![Pipeline](https://github.com/rtc-tools/rtc-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/rtc-tools/rtc-tools/actions/workflows/ci.yml)
+[![TeamCity](https://dpcbuild.deltares.nl/app/rest/builds/buildType:RTCT_RtcTools2_RtcToolsFullModelTests/statusIcon.svg)](https://dpcbuild.deltares.nl/buildConfiguration/RTCT_RtcTools2_RtcToolsFullModelTests)
 [![SonarCloud Alert Status](https://sonarcloud.io/api/project_badges/measure?project=rtc-tools_rtc-tools&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rtc-tools_rtc-tools)
-[![Coverage](
-    https://sonarcloud.io/api/project_badges/measure?project=rtc-tools_rtc-tools&metric=coverage
-)](https://sonarcloud.io/summary/new_code?id=rtc-tools_rtc-tools)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rtc-tools_rtc-tools&metric=coverage)](https://sonarcloud.io/summary/new_code?id=rtc-tools_rtc-tools)
+[![PyPI](https://img.shields.io/pypi/v/rtc-tools)](https://pypi.org/project/rtc-tools/)
+[![PyPI Downloads](https://static.pepy.tech/badge/rtc-tools/month)](https://pepy.tech/project/rtc-tools)
+[![Python](https://img.shields.io/pypi/pyversions/rtc-tools)](https://pypi.org/project/rtc-tools/)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+[![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=rtc-tools)](https://insights.linuxfoundation.org/project/rtc-tools)
+>>>>>>> 00d5f4d (docs(readme): add TeamCity, PyPI, LFX Health Score, and license badges)
 
 > **NOTE** The RTC-Tools repository has been migrated from GitLab to here;
 see [Migration from GitLab](#migration-from-gitlab).


### PR DESCRIPTION
Badges give users and contributors an at-a-glance view of the project's health, release status, teamcity test status, and compatibility without having to navigate away from the README.

- Add TeamCity build status badge (full model tests at dpcbuild.deltares.nl)
- Add PyPI version, monthly downloads, and supported Python versions badges
- Add LGPL v3 license badge
- Add LFX Health Score badge

Resolves #1808

This is how the new badges look like now:

<img width="1257" height="368" alt="Screenshot (291)" src="https://github.com/user-attachments/assets/c4a77c01-5f29-43b2-93fa-838ba30aa457" />
