### PR TITLE
fix: support CasADi 3.8 alongside 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,10 @@ classifiers = [
     "Operating System :: MacOS"
 ]
 dependencies = [
-    "casadi >= 3.6.3, < 3.8, !=3.6.6",
+    "casadi >= 3.6.3, < 3.9, !=3.6.6",
     "numpy >= 1.21.2",
     "scipy >= 1.7.2",
-    "pymoca >= 0.9.1, == 0.9.*",
+    "pymoca >= 0.9.3, == 0.9.*",
     "rtc-tools-channel-flow >= 1.2.0",
     "rtc-tools-standard-library >= 0.1.2",
     "defusedxml >= 0.7.0",

--- a/src/rtctools/optimization/optimization_problem.py
+++ b/src/rtctools/optimization/optimization_problem.py
@@ -166,6 +166,11 @@ class OptimizationProblem(DataStoreAccessor, metaclass=ABCMeta):
         if my_solver != "bonmin":
             nlpsol_options.pop("bonmin", None)
 
+        # nlpsol requires a dense 'f' and 'g'; an absent objective or a structurally
+        # zero residual transcribes to a sparse one.
+        nlp["f"] = ca.densify(nlp["f"])
+        nlp["g"] = ca.densify(nlp["g"])
+
         solver = casadi_solver("nlp", my_solver, nlp, nlpsol_options)
 
         # Solve NLP

--- a/src/rtctools/simulation/simulation_problem.py
+++ b/src/rtctools/simulation/simulation_problem.py
@@ -297,8 +297,8 @@ class SimulationProblem(DataStoreAccessor):
         )
         delay_time_values = delay_time_fun(*parameter_values)
         if len(delay_time_expressions) == 1:
-            return [delay_time_values]
-        return list(delay_time_values)
+            delay_time_values = [delay_time_values]
+        return [float(value) for value in delay_time_values]
 
     def _create_delay_expression_states(self):
         """
@@ -857,7 +857,7 @@ class SimulationProblem(DataStoreAccessor):
             next_state = self.__do_step(guess, dt, self.__state_vector)
 
         try:
-            if np.isnan(next_state).any():
+            if np.isnan(np.array(next_state)).any():
                 index_to_name = {index[0]: name for name, index in self.__indices.items()}
                 named_next_state = {
                     index_to_name[i]: float(next_state[i]) for i in range(0, next_state.shape[0])

--- a/uv.lock
+++ b/uv.lock
@@ -1340,16 +1340,16 @@ wheels = [
 
 [[package]]
 name = "pymoca"
-version = "0.9.2"
+version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/da/2abf5d074b6e69c190aac8fd6d2f732b2fcba0b73229776a18d4cace074f/pymoca-0.9.2.tar.gz", hash = "sha256:bb0f1368e67f7bb876c3cb3a468e4d3a87a28e7624adb7483b39a22274b730e0", size = 111886, upload-time = "2025-01-28T15:44:25.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/63/d425049b3a796f23918d5eeb19f062c089e4ac08f275b824337d49c0a3eb/pymoca-0.9.3.tar.gz", hash = "sha256:ecd000bd594aff0cbb4b80d42225d572dcb7fe92145f5f49141d01ae5972f767", size = 111993, upload-time = "2026-08-26T11:14:56.076Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/55/ecf41c62849b27684431f096872216427d6190dec2ee8d2c2550669d7395/pymoca-0.9.2-py3-none-any.whl", hash = "sha256:13b96bd877def818fba22f43b1b3916470b573e569c7e7f1bd98a8990b9b60d3", size = 113709, upload-time = "2025-01-28T15:44:22.626Z" },
+    { url = "https://files.pythonhosted.org/packages/db/5a/495956dda2b061dcaebc761e99b2ff478332fb027a40216b975677fa3fff/pymoca-0.9.3-py3-none-any.whl", hash = "sha256:e765e95471522987f68634625c3d47d806fd0dd198c16b8e53f66bd2008aa684", size = 113761, upload-time = "2026-08-26T11:14:54.772Z" },
 ]
 
 [[package]]
@@ -1580,12 +1580,12 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "casadi", specifier = ">=3.6.3,!=3.6.6,<3.8" },
+    { name = "casadi", specifier = ">=3.6.3,!=3.6.6,<3.9" },
     { name = "defusedxml", specifier = ">=0.7.0" },
     { name = "netcdf4", marker = "extra == 'all'" },
     { name = "netcdf4", marker = "extra == 'netcdf'" },
     { name = "numpy", specifier = ">=1.21.2" },
-    { name = "pymoca", specifier = "==0.9.*,>=0.9.1" },
+    { name = "pymoca", specifier = "==0.9.*,>=0.9.3" },
     { name = "rtc-tools-channel-flow", specifier = ">=1.2.0" },
     { name = "rtc-tools-standard-library", specifier = ">=0.1.2" },
     { name = "scipy", specifier = ">=1.7.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1607,7 +1607,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "sphinx", specifier = ">=7.0.0" },
     { name = "sphinx-rtd-theme", specifier = ">=1.3.0" },
-    { name = "sphinxcontrib-bibtex" },
+    { name = "sphinxcontrib-bibtex", specifier = ">=2.5.0" },
     { name = "tox", specifier = ">=4.18.0" },
     { name = "tox-uv", specifier = ">=1.25.0" },
 ]
@@ -1615,7 +1615,7 @@ docs = [
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "sphinx", specifier = ">=7.0.0" },
     { name = "sphinx-rtd-theme", specifier = ">=1.3.0" },
-    { name = "sphinxcontrib-bibtex" },
+    { name = "sphinxcontrib-bibtex", specifier = ">=2.5.0" },
 ]
 style = [{ name = "pre-commit", specifier = ">=3.3.0" }]
 tests = [


### PR DESCRIPTION
**Draft PR body written by Claude, on behalf of @jackvreeken.**

Opening this early as a draft so people know it is being worked on.

Widens the CasADi pin to `>= 3.6.3, < 3.9` (and bumps `pymoca` to `>= 0.9.3`) so RTC-Tools runs on both 3.7 and 3.8. On `master`, 12 tests fail under CasADi 3.8.

## Changes

**`nlpsol` requires a dense `f` and `g`.** CasADi 3.8 constant-folds a transcribed objective that evaluates to zero down to a structural zero (`1x1,0nz`), where 3.7 kept a live expression graph. `nlpsol` then trips its `Expected a dense 'f'` assertion. Fixed with `ca.densify` on `nlp["f"]`/`nlp["g"]` just before the solver is constructed. Note this assertion is not new in 3.8 — only the folding that triggers it is.

**Delay times are converted to `float` explicitly.** They were left as CasADi `DM`, which then flowed into `int(np.ceil(delay_time / dt))`.

**The nan check on the rootfinder result goes through `np.array` first**, rather than calling `np.isnan` on a `DM` directly.

## On the numpy interop

CasADi 3.8 adds `GlobalOptions.setNumpyMode` and emits a `FutureWarning` for the legacy behaviour. Under the opt-in `setNumpyMode(1)`, `np.isnan(DM)` raises `TypeError: ... returned NotImplemented from __array_ufunc__`, and `int(np.ceil(DM))` starts working — exactly the two sites touched here. So both changes move us toward the new mode rather than just silencing a warning.

Running the suite on 3.8 with `-W error::FutureWarning` shows no remaining legacy-numpy call sites in library code.

`setNumpyMode(1)` itself is **not** reachable yet: it produces 14 errors in the goal-programming tests, where numpy ufuncs applied to `MX` return an `ArrayInterfaceMX` that has no `.size1()` (surfacing at `collocated_integrated_optimization_problem.py:2005`). That is a separate piece of work — a library should not be setting the global mode itself anyway.

## Test status

363 passed, 1 skipped on both CasADi 3.7.2 and 3.8.0, with numpy/scipy/pymoca held identical across the two runs.

## Known open items

- `SimulationProblem` builds its own `nlp` and calls `ca.nlpsol` at `simulation_problem.py:673` without the `densify` guard. No reproducer found so far, but it is the same exposure.
- `update()` now converts the result `DM` to numpy twice per timestep — once for the nan check, once for the state-vector write. Reusing a single conversion halves that block. Worth about 1% of a step with the default `nlpsol`/ipopt rootfinder, and about 7% with `newton`/`fast_newton`. Measured as roughly 51% off the conversion block itself at every model size from 1k to 100k states.
- The nan-reporting path in `update()` has no test coverage at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
