### PR TITLE
perf(simulation): convert the rootfinder result to numpy once per step

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,10 @@ classifiers = [
     "Operating System :: MacOS"
 ]
 dependencies = [
-    "casadi >= 3.6.3, < 3.8, !=3.6.6",
+    "casadi >= 3.6.3, < 3.9, !=3.6.6",
     "numpy >= 1.21.2",
     "scipy >= 1.7.2",
-    "pymoca >= 0.9.1, == 0.9.*",
+    "pymoca >= 0.9.3, == 0.9.*",
     "rtc-tools-channel-flow >= 1.2.0",
     "rtc-tools-standard-library >= 0.1.2",
     "defusedxml >= 0.7.0",

--- a/src/rtctools/optimization/optimization_problem.py
+++ b/src/rtctools/optimization/optimization_problem.py
@@ -166,6 +166,11 @@ class OptimizationProblem(DataStoreAccessor, metaclass=ABCMeta):
         if my_solver != "bonmin":
             nlpsol_options.pop("bonmin", None)
 
+        # nlpsol requires a dense 'f' and 'g'; an absent objective or a structurally
+        # zero residual transcribes to a sparse one.
+        nlp["f"] = ca.densify(nlp["f"])
+        nlp["g"] = ca.densify(nlp["g"])
+
         solver = casadi_solver("nlp", my_solver, nlp, nlpsol_options)
 
         # Solve NLP

--- a/src/rtctools/simulation/simulation_problem.py
+++ b/src/rtctools/simulation/simulation_problem.py
@@ -852,19 +852,15 @@ class SimulationProblem(DataStoreAccessor):
         else:
             next_state = self.__do_step(guess, dt, self.__state_vector)
 
+        next_state_values = next_state.toarray().ravel()
+
         try:
-            if np.isnan(np.array(next_state)).any():
+            if np.isnan(next_state_values).any():
                 index_to_name = {index[0]: name for name, index in self.__indices.items()}
-                named_next_state = {
-                    index_to_name[i]: float(next_state[i]) for i in range(0, next_state.shape[0])
-                }
                 variables_with_nan = [
-                    name for name, value in named_next_state.items() if np.isnan(value)
+                    index_to_name[i] for i in np.flatnonzero(np.isnan(next_state_values))
                 ]
-                if variables_with_nan:
-                    logger.error(
-                        f"Found nan(s) in the next_state vector for:\n\t {variables_with_nan}"
-                    )
+                logger.error(f"Found nan(s) in the next_state vector for:\n\t {variables_with_nan}")
         except (KeyError, IndexError, TypeError):
             logger.warning("Something went wrong while checking for nans in the next_state vector")
 
@@ -888,7 +884,7 @@ class SimulationProblem(DataStoreAccessor):
             logger.debug(f"Residual maximum magnitude: {float(largest_res):.2E}")
 
         # Update state vector
-        self.__state_vector[: self.__n_states] = next_state.toarray().ravel()
+        self.__state_vector[: self.__n_states] = next_state_values
 
     def simulate(self):
         """

--- a/src/rtctools/simulation/simulation_problem.py
+++ b/src/rtctools/simulation/simulation_problem.py
@@ -297,8 +297,8 @@ class SimulationProblem(DataStoreAccessor):
         )
         delay_time_values = delay_time_fun(*parameter_values)
         if len(delay_time_expressions) == 1:
-            return [delay_time_values]
-        return list(delay_time_values)
+            delay_time_values = [delay_time_values]
+        return [float(value) for value in delay_time_values]
 
     def _create_delay_expression_states(self):
         """
@@ -853,7 +853,7 @@ class SimulationProblem(DataStoreAccessor):
             next_state = self.__do_step(guess, dt, self.__state_vector)
 
         try:
-            if np.isnan(next_state).any():
+            if np.isnan(np.array(next_state)).any():
                 index_to_name = {index[0]: name for name, index in self.__indices.items()}
                 named_next_state = {
                     index_to_name[i]: float(next_state[i]) for i in range(0, next_state.shape[0])

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -161,6 +161,41 @@ class TestSimulation(TestCase):
         seed = self.problem.seed()
         self.assertEqual(seed["z"], 1.0)
 
+    def test_nan_in_next_state_is_reported(self):
+        """Test that a nan in the rootfinder result is logged with the variable it belongs to."""
+        self.problem.setup_experiment(0.0, 1.0, 0.1)
+        self.problem.set_var("x_start", 0.25)
+        self.problem.set_var("constant_input", 0.0)
+        self.problem.set_var("u", 0.0)
+        self.problem.initialize()
+
+        index, _ = self.problem._SimulationProblem__indices["w"]
+        n_states = self.problem._SimulationProblem__n_states
+        self.problem._SimulationProblem__do_step = NanStep(n_states, index)
+
+        with self.assertLogs("rtctools", "ERROR") as context_manager:
+            self.problem.update(0.1)
+
+        self.assertTrue(
+            contains_regex(
+                r"(?s)Found nan\(s\) in the next_state vector.*'w'", context_manager.output
+            )
+        )
+
+
+class NanStep:
+    """Stand-in for the rootfinder, returning a state vector with a nan at ``nan_index``."""
+
+    def __init__(self, n_states, nan_index):
+        self.values = np.zeros(n_states)
+        self.values[nan_index] = np.nan
+
+    def __call__(self, *args):
+        return ca.DM(self.values)
+
+    def stats(self):
+        return {"success": True}
+
 
 class SimulationModelBase(SimulationProblem):
     _force_zero_delay = True

--- a/uv.lock
+++ b/uv.lock
@@ -1340,16 +1340,16 @@ wheels = [
 
 [[package]]
 name = "pymoca"
-version = "0.9.2"
+version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/da/2abf5d074b6e69c190aac8fd6d2f732b2fcba0b73229776a18d4cace074f/pymoca-0.9.2.tar.gz", hash = "sha256:bb0f1368e67f7bb876c3cb3a468e4d3a87a28e7624adb7483b39a22274b730e0", size = 111886, upload-time = "2025-01-28T15:44:25.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/63/d425049b3a796f23918d5eeb19f062c089e4ac08f275b824337d49c0a3eb/pymoca-0.9.3.tar.gz", hash = "sha256:ecd000bd594aff0cbb4b80d42225d572dcb7fe92145f5f49141d01ae5972f767", size = 111993, upload-time = "2026-08-26T11:14:56.076Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/55/ecf41c62849b27684431f096872216427d6190dec2ee8d2c2550669d7395/pymoca-0.9.2-py3-none-any.whl", hash = "sha256:13b96bd877def818fba22f43b1b3916470b573e569c7e7f1bd98a8990b9b60d3", size = 113709, upload-time = "2025-01-28T15:44:22.626Z" },
+    { url = "https://files.pythonhosted.org/packages/db/5a/495956dda2b061dcaebc761e99b2ff478332fb027a40216b975677fa3fff/pymoca-0.9.3-py3-none-any.whl", hash = "sha256:e765e95471522987f68634625c3d47d806fd0dd198c16b8e53f66bd2008aa684", size = 113761, upload-time = "2026-08-26T11:14:54.772Z" },
 ]
 
 [[package]]
@@ -1580,12 +1580,12 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "casadi", specifier = ">=3.6.3,!=3.6.6,<3.8" },
+    { name = "casadi", specifier = ">=3.6.3,!=3.6.6,<3.9" },
     { name = "defusedxml", specifier = ">=0.7.0" },
     { name = "netcdf4", marker = "extra == 'all'" },
     { name = "netcdf4", marker = "extra == 'netcdf'" },
     { name = "numpy", specifier = ">=1.21.2" },
-    { name = "pymoca", specifier = "==0.9.*,>=0.9.1" },
+    { name = "pymoca", specifier = "==0.9.*,>=0.9.3" },
     { name = "rtc-tools-channel-flow", specifier = ">=1.2.0" },
     { name = "rtc-tools-standard-library", specifier = ">=0.1.2" },
     { name = "scipy", specifier = ">=1.7.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1607,7 +1607,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "sphinx", specifier = ">=7.0.0" },
     { name = "sphinx-rtd-theme", specifier = ">=1.3.0" },
-    { name = "sphinxcontrib-bibtex" },
+    { name = "sphinxcontrib-bibtex", specifier = ">=2.5.0" },
     { name = "tox", specifier = ">=4.18.0" },
     { name = "tox-uv", specifier = ">=1.25.0" },
 ]
@@ -1615,7 +1615,7 @@ docs = [
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "sphinx", specifier = ">=7.0.0" },
     { name = "sphinx-rtd-theme", specifier = ">=1.3.0" },
-    { name = "sphinxcontrib-bibtex" },
+    { name = "sphinxcontrib-bibtex", specifier = ">=2.5.0" },
 ]
 style = [{ name = "pre-commit", specifier = ">=3.3.0" }]
 tests = [


### PR DESCRIPTION
**Draft PR body written by Claude, on behalf of @jackvreeken.**

Noticed while benchmarking #1821. Unrelated to CasADi 3.8 — this inefficiency predates it — but it touches the same line, so this is stacked on that branch to avoid a conflict. **Base retargets to `master` automatically once #1821 merges.**

## What

`SimulationProblem.update()` builds a numpy copy of the rootfinder result twice per timestep: once for the nan check, and once more at the bottom for the state-vector write. Both want the same buffer. This takes it once and reuses it.

## Numbers

Measured on CasADi 3.8.0, comparing the two-conversion and one-conversion forms of the nan-check-plus-state-write block:

| n_states | two conversions | one conversion | saved |
|---|---|---|---|
| 1 000 | 76.5 µs | 37.5 µs | 51% |
| 10 000 | 692 µs | 343 µs | 51% |
| 100 000 | 10.4 ms | 5.07 ms | 51% |

As a share of a whole timestep that depends on the rootfinder. Against the default `nlpsol`/ipopt it is worth about 1%; against `newton` or `fast_newton` the block is 13–17% of a step and this takes about 7% off, roughly flat across sizes.

For reference, `DM.is_regular()` is 50–70× faster than any numpy round-trip (0.77 µs vs 37 µs at n=1000), but it buys nothing here — `toarray()` has to happen anyway for the state-vector write — and it flags inf as well as nan.

## Knock-on in the nan branch

With the values already in an array, there is no reason to name every state just to find the few that are nan. `np.flatnonzero` gives the nan indices directly, so only those get looked up, and the `named_next_state` dict goes away.

One behaviour change falls out of that: the old code looked up `index_to_name[i]` for *every* index, so a single index missing from the map raised `KeyError` and the whole report degraded to "Something went wrong while checking for nans". Only nan indices are looked up now, so the report survives that case.

## Test

That reporting path had no coverage at all, which is why the restructure above was worth pinning down. The new test stands in for the rootfinder with a result containing a nan and asserts the offending variable is named.

It is a characterization test, not a regression test — **it passes on the old code too**. It reaches for name-mangled internals, which is not pretty; getting IPOPT to return a nan solution naturally did not work out, as a nan input trips the pre-step check and fails with `Invalid_Number_Detected` before the code under test is reached.

## Test status

364 passed, 1 skipped on both CasADi 3.7.2 and 3.8.0, with numpy/scipy/pymoca held identical across the two runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
